### PR TITLE
BaseStylesheet Property Mutliline Edit Support

### DIFF
--- a/Source/HtmlRenderer/HtmlLabel.cs
+++ b/Source/HtmlRenderer/HtmlLabel.cs
@@ -183,7 +183,7 @@ namespace HtmlRenderer
         [Browsable(true)]
         [Description("Set base stylesheet to be used by html rendered in the control.")]
         [Category("Appearance")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
         public string BaseStylesheet
         {
             get { return _baseRawCssData; }

--- a/Source/HtmlRenderer/HtmlPanel.cs
+++ b/Source/HtmlRenderer/HtmlPanel.cs
@@ -193,7 +193,7 @@ namespace HtmlRenderer
         [Browsable(true)]
         [Category("Appearance")]
         [Description("Set base stylesheet to be used by html rendered in the control.")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
         public string BaseStylesheet
         {
             get { return _baseRawCssData; }

--- a/Source/HtmlRenderer/HtmlToolTip.cs
+++ b/Source/HtmlRenderer/HtmlToolTip.cs
@@ -131,7 +131,7 @@ namespace HtmlRenderer
         [Browsable(true)]
         [Description("Set base stylesheet to be used by html rendered in the tooltip.")]
         [Category("Appearance")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
         public string BaseStylesheet
         {
             get { return _baseRawCssData; }


### PR DESCRIPTION
Whoosh. What a pain that was trying to get only a single commit into a pull request rather than all the other bits I'm poking around with!

This pull request simply adds the `Editor` attribute to the `BaseStylesheet` properties of the `HtmlLabel`, `HtmlPanel` and `HtmlToolTip` controls to specify that these properties should use the `MultilineStringEditor`, which makes it a bit easier to edit CSS instead of trying to fiddle it into a single line. Uses fully qualified assembly names rather than type references so clients you don't have to have references to System.Design etc, instead .NET will handle it all for you.

Regards;
Richard Moss
