### PR TITLE
Extend CssParser quote support

### DIFF
--- a/Source/HtmlRenderer/Parse/CssParser.cs
+++ b/Source/HtmlRenderer/Parse/CssParser.cs
@@ -553,9 +553,9 @@ namespace HtmlRenderer.Parse
                 if(endIdx > -1)
                 {
                     endIdx -= 1;
-                    while (startIdx < endIdx && (char.IsWhiteSpace(propValue[startIdx]) || propValue[startIdx] == '\''))
+                    while (startIdx < endIdx && (char.IsWhiteSpace(propValue[startIdx]) || propValue[startIdx] == '\'' || propValue[startIdx] == '"'))
                         startIdx++;
-                    while (startIdx < endIdx && (char.IsWhiteSpace(propValue[endIdx]) || propValue[endIdx] == '\''))
+                    while (startIdx < endIdx && (char.IsWhiteSpace(propValue[endIdx]) || propValue[endIdx] == '\'' || propValue[endIdx] == '"'))
                         endIdx--;
 
                     if (startIdx <= endIdx)


### PR DESCRIPTION
Updates the CssParser.ParseBackgroundImageProperty method to correctly support values surrounded with double quotes. (Fix for work item 9037 on CodePlex)
