### PR TITLE
Fix of memory leak with Hover boxes inside HtmlContainerInt.

### DIFF
--- a/Source/HtmlRenderer/Core/HtmlContainerInt.cs
+++ b/Source/HtmlRenderer/Core/HtmlContainerInt.cs
@@ -425,6 +425,8 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// </summary>
         public void Clear()
         {
+            _hoverBoxes.Clear();
+
             if (_root != null)
             {
                 _root.Dispose();


### PR DESCRIPTION
This commit will fix of memory leak with Hover boxes inside HtmlContainerInt.
_hoverBoxes kept links even if control was cleared

If text inside HtmlControl was changed then HtmlContainer clears. But _hoverBoxes still contains reference to elements and produces a memory leak.
