### PR TITLE
ColorConverter exception prevention

### DIFF
--- a/Source/Demo/Common/Resources/Tooltip.html
+++ b/Source/Demo/Common/Resources/Tooltip.html
@@ -1,4 +1,4 @@
-﻿<b>HtmlPnael control showing <u>HTML Renderer</u> capabilities</b>
+﻿<b>HtmlPanel control showing <u>HTML Renderer</u> capabilities</b>
 <table border="0" style="margin: 10px 20px;">
     <tr>
         <td width="32" style="padding: 2px 5px 0 0">

--- a/Source/HtmlRenderer.WPF/Adapters/WpfAdapter.cs
+++ b/Source/HtmlRenderer.WPF/Adapters/WpfAdapter.cs
@@ -11,7 +11,9 @@
 // "The Art of War"
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -34,8 +36,22 @@ namespace TheArtOfDev.HtmlRenderer.WPF.Adapters
         /// </summary>
         private static readonly WpfAdapter _instance = new WpfAdapter();
 
+        /// <summary>
+        /// List of valid predefined color names in lower-case
+        /// </summary>
+        private static readonly List<string> ValidColorNamesLc; 
+
         #endregion
 
+        static WpfAdapter()
+        {
+            ValidColorNamesLc = new List<string>();
+            var colorList = new List<PropertyInfo>(typeof(Colors).GetProperties());
+            foreach (var colorProp in colorList)
+            {
+                ValidColorNamesLc.Add(colorProp.Name.ToLower());
+            }
+        }
 
         /// <summary>
         /// Init installed font families and set default font families mapping.
@@ -61,6 +77,10 @@ namespace TheArtOfDev.HtmlRenderer.WPF.Adapters
 
         protected override RColor GetColorInt(string colorName)
         {
+            // check if color name is valid to avoid ColorConverter throwing an exception
+            if (!ValidColorNamesLc.Contains(colorName.ToLower()))
+                return RColor.Empty;
+
             var convertFromString = ColorConverter.ConvertFromString(colorName) ?? Colors.Black;
             return Utils.Convert((Color)convertFromString);
         }


### PR DESCRIPTION
I have made a small fix that prevents the ColorConverter from throwing several exceptions during startup when trying to parse default border color. When you enable "break-on-exception" to catch your own bugs it can be somewhat annoying to have a library throwing exceptions during normal startup.

Also I fixed a small typo.

Apart from that I will just say thanks for the great library! It fills a big hole in the WPF widget with the standard Microsoft WebBrowser widget being little more than a WinForms control in disguise.