### PR TITLE
ENABLED SAVING HTML AS EMF FILE (VECTORIAL IMAGE): 

### DIFF
--- a/Source/HtmlRenderer.WinForms/HtmlRender.cs
+++ b/Source/HtmlRenderer.WinForms/HtmlRender.cs
@@ -273,6 +273,29 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         }
 
 #if !MONO
+
+        public static Metafile RenderToMetafile(string html, float left = 0, float top = 0, float maxWidth = 0, CssData cssData = null,
+            EventHandler<HtmlStylesheetLoadEventArgs> stylesheetLoad = null, EventHandler<HtmlImageLoadEventArgs> imageLoad = null)
+        {
+            Metafile image;
+            IntPtr dib;
+            var memoryHdc = Win32Utils.CreateMemoryHdc(IntPtr.Zero, 1, 1, out dib);
+            try
+            {
+                image = new Metafile(memoryHdc, EmfType.EmfPlusDual, "..");
+
+                using (var g = Graphics.FromImage(image))
+                {
+                    Render(g, html, left, top, maxWidth, cssData, stylesheetLoad, imageLoad);
+                }
+            }
+            finally
+            {
+                Win32Utils.ReleaseMemoryHdc(memoryHdc, dib);
+            }
+            return image;
+        }
+
         /// <summary>
         /// Renders the specified HTML on top of the given image.<br/>
         /// <paramref name="image"/> will contain the rendered html in it on top of original content.<br/>

--- a/Source/HtmlRenderer.WinForms/HtmlRenderer.WinForms.csproj
+++ b/Source/HtmlRenderer.WinForms/HtmlRenderer.WinForms.csproj
@@ -87,6 +87,7 @@
     <Compile Include="HtmlToolTip.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="MetafileExtensions.cs" />
     <Compile Include="Utilities\ClipboardHelper.cs" />
     <Compile Include="Utilities\Utils.cs" />
     <Compile Include="Utilities\Win32Utils.cs" />

--- a/Source/HtmlRenderer.WinForms/MetafileExtensions.cs
+++ b/Source/HtmlRenderer.WinForms/MetafileExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace TheArtOfDev.HtmlRenderer.WinForms
+{
+    public static class MetafileExtensions
+    {
+        public static void SaveAsEmf(Metafile me, string fileName)
+        {
+            /* http://social.msdn.microsoft.com/Forums/en-US/csharpgeneral/thread/12a1c749-b320-4ce9-aff7-9de0d7fd30ea 
+                How to save or serialize a Metafile: Solution found 
+                by : SWAT Team member _1 
+                Date : Friday, February 01, 2008 1:38 PM 
+                */
+            int enfMetafileHandle = me.GetHenhmetafile().ToInt32();
+            int bufferSize = GetEnhMetaFileBits(enfMetafileHandle, 0, null); // Get required buffer size.  
+            byte[] buffer = new byte[bufferSize]; // Allocate sufficient buffer  
+            if (GetEnhMetaFileBits(enfMetafileHandle, bufferSize, buffer) <= 0) // Get raw metafile data.  
+                throw new SystemException("Fail");
+
+            FileStream ms = File.Open(fileName, FileMode.Create);
+            ms.Write(buffer, 0, bufferSize);
+            ms.Close();
+            ms.Dispose();
+            if (!DeleteEnhMetaFile(enfMetafileHandle)) //free handle  
+                throw new SystemException("Fail Free");
+        }
+
+        [DllImport("gdi32")]
+        public static extern int GetEnhMetaFileBits(int hemf, int cbBuffer, byte[] lpbBuffer);
+
+        [DllImport("gdi32")]
+        public static extern bool DeleteEnhMetaFile(int hemfbitHandle);
+    }  
+}


### PR DESCRIPTION
Added 
- HtmlRender.RenderToMetafile(...) 
- MetafileExtensions.SaveAsEmf(...) method

So that you can export an html document to vector-image file (emf/wmf) as following:

```C#
Metafile image = HtmlRender.RenderToMetafile(html);
MetafileExtensions.SaveAsEmf(image, "c:\temp\myEmfFile.emf");
```

This new feature is not covered by any unit test / test.
It is just a suggestion: I use similar code for the documentation of [NCase](https://github.com/jeromerg/NCase). It allows to generate vector-based images, which can be inserted into powerpoint slides, without taking care of resolution/pixelization.
