### PR TITLE
Fixes WPF text blurry render encountered in some cases.

### DIFF
--- a/Source/HtmlRenderer.WPF/Adapters/GraphicsAdapter.cs
+++ b/Source/HtmlRenderer.WPF/Adapters/GraphicsAdapter.cs
@@ -201,7 +201,15 @@ namespace TheArtOfDev.HtmlRenderer.WPF.Adapters
 
                     glyphRendered = true;
                     var glyphRun = new GlyphRun(glyphTypeface, rtl ? 1 : 0, false, 96d / 72d * font.Size, glyphs, Utils.ConvertRound(point), widths, null, null, null, null, null, null);
+                    var rect = glyphRun.ComputeAlignmentBox();
+                    var guidelines = new GuidelineSet();
+                    guidelines.GuidelinesX.Add(rect.Left);
+                    guidelines.GuidelinesX.Add(rect.Right);
+                    guidelines.GuidelinesY.Add(rect.Top);
+                    guidelines.GuidelinesY.Add(rect.Bottom);
+                    _g.PushGuidelineSet(guidelines);
                     _g.DrawGlyphRun(colorConv, glyphRun);
+                    _g.Pop();
                 }
             }
 
@@ -269,7 +277,7 @@ namespace TheArtOfDev.HtmlRenderer.WPF.Adapters
                 x += .5;
                 y += .5;
             }
-            
+
             _g.DrawRectangle(null, ((PenAdapter)pen).CreatePen(), new Rect(x, y, width, height));
         }
 


### PR DESCRIPTION
This fixes "blurry" text rendering in the WPF GraphicsAdapter.
I encountered this issue in the following cases:
 - HtmlPanel embedded in Tooltip
 - HtmlPanel used in ItemTemplate

The changes in this PR fixe my issues, but I haven't performed further testing. Any help from the community would be much appreciated.

My fix has greatly been inspired by this post : http://wpftutorial.net/DrawOnPhysicalDevicePixels.html. Might be usefull for the review.