### PR TITLE
Removed System.Windows.Forms dependency in WPF nuspec file

### DIFF
--- a/Build/NuGet/HtmlRenderer.WPF.nuspec
+++ b/Build/NuGet/HtmlRenderer.WPF.nuspec
@@ -35,7 +35,6 @@
     <releaseNotes>See http://htmlrenderer.codeplex.com/releases.</releaseNotes>
     <tags>html render renderer draw control WPF</tags>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.Windows.Forms" targetFramework="" />
       <frameworkAssembly assemblyName="System.Drawing" targetFramework="" />
     </frameworkAssemblies>
     <dependencies>


### PR DESCRIPTION
As far as I can see this framework reference isn't required because the core and the WPF projects don't include this reference.