### PR TITLE
Fix for combining bold with italic in WPF

### DIFF
--- a/Source/Demo/Common/Samples/02.Text.htm
+++ b/Source/Demo/Common/Samples/02.Text.htm
@@ -23,7 +23,7 @@
                 <li><span style="color: red">Colors</span>, <span style="color: #8dd">Colors</span>,
                     <span style="color: rgb(160, 80, 90)">Colors</span></li>
                 <li><span style="background-color: red">Back colors</span>, <span style="background-color: #8dd">Back colors</span>, <span style="background-color: rgb(160, 80, 90)">Back colors</span></li>
-                <li><span style="font-style: normal">Font style</span>, <span style="font-style: italic">Font style</span>, <span style="font-weight: bolder">Font style</span>, <span style="text-decoration: underline">Font style</span>, <span style="text-decoration: line-through">Font style</span></li>
+                <li><span style="font-style: normal">Font style</span>, <span style="font-style: italic">Font style</span>, <span style="font-weight: bolder">Font style</span>, <span style="font-style: italic;font-weight: bolder">Font style</span>, <span style="text-decoration: underline">Font style</span>, <span style="text-decoration: line-through">Font style</span></li>
             </ul>
             <p>
                 Lorem ipsum <span style="font-style: italic; text-decoration: underline">dolor sit amet</span>,

--- a/Source/Demo/Common/Samples/03.Tables.htm
+++ b/Source/Demo/Common/Samples/03.Tables.htm
@@ -77,7 +77,7 @@
                             <li><span style="background-color: red">Back colors</span>, <span style="background-color: #8dd">
                                                                                             Back colors</span>, <span style="background-color: rgb(160, 80, 90)">Back colors</span></li>
                             <li><span style="font-style: normal">Font style</span>, <span style="font-style: italic">
-                                                                                        Font style</span>, <span style="font-weight: bolder">Font style</span>, <span style="text-decoration: underline">
+                                                                                        Font style</span>, <span style="font-weight: bolder">Font style</span>, <span style="font-style: italic;font-weight: bolder">Font style</span>, <span style="text-decoration: underline">
                                                                                                                                                                     Font style</span>, <span style="text-decoration: line-through">Font style</span></li>
                         </ul>
                     </td>

--- a/Source/HtmlRenderer.WPF/Adapters/WpfAdapter.cs
+++ b/Source/HtmlRenderer.WPF/Adapters/WpfAdapter.cs
@@ -207,13 +207,10 @@ namespace TheArtOfDev.HtmlRenderer.WPF.Adapters
         /// </summary>
         private static FontStyle GetFontStyle(RFontStyle style)
         {
-            switch (style)
-            {
-                case RFontStyle.Italic:
-                    return FontStyles.Italic;
-                default:
-                    return FontStyles.Normal;
-            }
+            if ((style & RFontStyle.Italic) == RFontStyle.Italic)
+                return FontStyles.Italic;
+
+            return FontStyles.Normal;
         }
 
         /// <summary>
@@ -221,13 +218,10 @@ namespace TheArtOfDev.HtmlRenderer.WPF.Adapters
         /// </summary>
         private static FontWeight GetFontWidth(RFontStyle style)
         {
-            switch (style)
-            {
-                case RFontStyle.Bold:
-                    return FontWeights.Bold;
-                default:
-                    return FontWeights.Normal;
-            }
+            if ((style & RFontStyle.Bold) == RFontStyle.Bold)
+                return FontWeights.Bold;
+
+            return FontWeights.Normal;
         }
 
         #endregion


### PR DESCRIPTION
Checking if the RFontStyle flag is set instead of checking the value only, (Bold | Italic) would fall through to default instead of the desired values.

Adding bold and italic font style span to sample html. 

#83 