### PR TITLE
#94 Fixed issue where parsing font values with trailing commas causes…

### DIFF
--- a/Source/HtmlRenderer/Core/Parse/CssParser.cs
+++ b/Source/HtmlRenderer/Core/Parse/CssParser.cs
@@ -625,9 +625,10 @@ namespace TheArtOfDev.HtmlRenderer.Core.Parse
         private string ParseFontFamilyProperty(string propValue)
         {
             int start = 0;
-            while (start > -1 && start < propValue.Length)
+
+            while (start < propValue.Length)
             {
-                while (char.IsWhiteSpace(propValue[start]) || propValue[start] == ',' || propValue[start] == '\'' || propValue[start] == '"')
+                while (start < propValue.Length && (char.IsWhiteSpace(propValue[start]) || propValue[start] == ',' || propValue[start] == '\'' || propValue[start] == '"'))
                     start++;
                 var end = propValue.IndexOf(',', start);
                 if (end < 0)
@@ -639,9 +640,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Parse
                 var font = propValue.Substring(start, adjEnd - start + 1);
 
                 if (_adapter.IsFontExists(font))
-                {
                     return font;
-                }
 
                 start = end;
             }


### PR DESCRIPTION
… an IndexOutOfRangeException.

When dealing with a property value with a trailing comma, the code would try to start from that comma, and increase the start index by one. This would cause the start index to go out of bounds since it was the last character in the string.

Also removed the check for start being greater than -1 since the start index is never decremented.
This fixes #94.