### PR TITLE
Update all dependencies

### DIFF
--- a/Source/Demo/WPF/HtmlRenderer.Demo.WPF.csproj
+++ b/Source/Demo/WPF/HtmlRenderer.Demo.WPF.csproj
@@ -26,7 +26,7 @@
     <Resource Include="fonts\CustomFont.ttf" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="2.2.1" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="5.0.0" />
   </ItemGroup>
   <Target Name="AfterResolveReferences">
     <ItemGroup>

--- a/Source/Demo/WinForms/HtmlRenderer.Demo.WinForms.csproj
+++ b/Source/Demo/WinForms/HtmlRenderer.Demo.WinForms.csproj
@@ -27,14 +27,4 @@
   <ItemGroup>
     <EmbeddedResource Include="html.ico" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="PDFsharp" Version="1.50.4000-beta3b" />
-  </ItemGroup>
-  <Target Name="AfterResolveReferences">
-    <ItemGroup>
-      <EmbeddedResource Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.Extension)' == '.dll'">
-        <LogicalName>%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)</LogicalName>
-      </EmbeddedResource>
-    </ItemGroup>
-  </Target>
 </Project>

--- a/Source/HtmlRenderer.PdfSharp/HtmlRenderer.PdfSharp.csproj
+++ b/Source/HtmlRenderer.PdfSharp/HtmlRenderer.PdfSharp.csproj
@@ -28,12 +28,12 @@ Features and Benefits:
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HtmlRenderer\HtmlRenderer.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="PDFsharp" Version="1.50.4000-beta3b" />
+    <PackageReference Include="PDFsharp" Version="1.50.5147" />
   </ItemGroup>
 </Project>

--- a/Source/HtmlRenderer/HtmlRenderer.csproj
+++ b/Source/HtmlRenderer/HtmlRenderer.csproj
@@ -26,9 +26,9 @@ For existing implementations see: HtmlRenderer.WinForms, HtmlRenderer.WPF and Ht
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Resources.Extensions" Version="4.6.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="10.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The updated dependencies are still fully compatible with .NET Framework 4.6.2

- Extended.Wpf.Toolkit: 2.2.1 -> 5.0.0
- PDFsharp: 1.50.4000-beta3b -> 1.50.5147
- System.Resources.Extensions: 4.6.0 -> 10.0.0

PDFsharp isn't updated to the latest available/stable version 6.2.3, because there are breaking changes that would need to be addressed. See Phase 3 of the Roadmap #219 