### PR TITLE
Fix YouTube & Vimeo video embedding

### DIFF
--- a/Source/Demo/Common/Samples/06.Embeded video.htm
+++ b/Source/Demo/Common/Samples/06.Embeded video.htm
@@ -33,7 +33,8 @@
             <h2>
                 Example
             </h2>
-            <iframe height="360" width="480" src="https://www.youtube.com/embed/2l_PmSOreGc" />
+            <iframe height="360" width="480" src="https://www.youtube.com/embed/2l_PmSOreGc" /><br /><br />
+            <iframe height="270" width="480" src="https://player.vimeo.com/video/170338499" />
         </blockquote>
     </body>
 </html>

--- a/Source/HtmlRenderer/Core/Dom/CssBoxFrame.cs
+++ b/Source/HtmlRenderer/Core/Dom/CssBoxFrame.cs
@@ -321,7 +321,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
                             if (idx > -1)
                             {
                                 var endIdx = e.Result.IndexOf('"', idx + 1);
-                                while (e.Result[endIdx - 1] == '\\')
+                                while (endIdx > 0 && e.Result[endIdx - 1] == '\\')
                                     endIdx = e.Result.IndexOf('"', endIdx + 1);
                                 if (endIdx > -1)
                                 {
@@ -337,49 +337,59 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
                                 Width = "640";
                             if (string.IsNullOrEmpty(Height))
                                 Height = "360";
+                            var urlIdx = e.Result.IndexOf("\"https:\\/\\/", idx);
+                            if (urlIdx != -1)
+                                idx = urlIdx;
                         }
                         else
                         {
-                            idx = e.Result.IndexOf("thumbnail_medium", idx);
+                            idx = e.Result.IndexOf("\"thumbnail_medium\"", StringComparison.Ordinal);
                             if (idx > -1)
                             {
                                 if (string.IsNullOrEmpty(Width))
                                     Width = "200";
                                 if (string.IsNullOrEmpty(Height))
                                     Height = "150";
+                                var urlIdx = e.Result.IndexOf("\"https:\\/\\/", idx);
+                                if (urlIdx != -1)
+                                    idx = urlIdx;
                             }
                             else
                             {
-                                idx = e.Result.IndexOf("thumbnail_small", idx);
-                                if (string.IsNullOrEmpty(Width))
-                                    Width = "100";
-                                if (string.IsNullOrEmpty(Height))
-                                    Height = "75";
+                                idx = e.Result.IndexOf("\"thumbnail_small\"", StringComparison.Ordinal);
+                                if (idx > -1)
+                                {
+                                    if (string.IsNullOrEmpty(Width))
+                                        Width = "100";
+                                    if (string.IsNullOrEmpty(Height))
+                                        Height = "75";
+                                    var urlIdx = e.Result.IndexOf("\"https:\\/\\/", idx);
+                                    if (urlIdx != -1)
+                                        idx = urlIdx;
+                                }
                             }
                         }
                         if (idx > -1)
                         {
-                            idx = e.Result.IndexOf("http:", idx);
-                            if (idx > -1)
+                            idx = idx + 1;
+                            var endIdx = e.Result.IndexOf('"', idx);
+                            if (endIdx > -1)
                             {
-                                var endIdx = e.Result.IndexOf('"', idx);
-                                if (endIdx > -1)
-                                {
-                                    _videoImageUrl = e.Result.Substring(idx, endIdx - idx).Replace("\\\"", "\"").Replace("\\", "");
-                                }
+                                _videoImageUrl = e.Result.Substring(idx, endIdx - idx).Replace("\\/", "/");
                             }
                         }
 
                         idx = e.Result.IndexOf("\"url\"", StringComparison.Ordinal);
                         if (idx > -1)
                         {
-                            idx = e.Result.IndexOf("http:", idx);
+                            idx = e.Result.IndexOf("\"https:\\/\\/", idx);
                             if (idx > -1)
                             {
+                                idx = idx + 1;
                                 var endIdx = e.Result.IndexOf('"', idx);
                                 if (endIdx > -1)
                                 {
-                                    _videoLinkUrl = e.Result.Substring(idx, endIdx - idx).Replace("\\\"", "\"").Replace("\\", "");
+                                    _videoLinkUrl = e.Result.Substring(idx, endIdx - idx).Replace("\\/", "/");
                                 }
                             }
                         }


### PR DESCRIPTION
YouTub's V2 API has been shutdown and V3 requires authentication via API key.  
Luckily the oembed API is still publicly available.

Vimeo has a slightly different response, which needed adjusting in the parsing.

## WinForms

<img width="529" height="695" alt="image" src="https://github.com/user-attachments/assets/d984d271-3806-4deb-8194-08de34f4a7f2" />

## WPF

<img width="529" height="700" alt="image" src="https://github.com/user-attachments/assets/c6695ee6-5bf7-482e-a77c-9e11180237c9" />
