### PR TITLE
Do not inherit "vertical-align"

### DIFF
--- a/Source/HtmlRenderer/Core/Dom/CssBoxProperties.cs
+++ b/Source/HtmlRenderer/Core/Dom/CssBoxProperties.cs
@@ -1499,7 +1499,6 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
                 _visibility = p._visibility;
                 _textIndent = p._textIndent;
                 _textAlign = p._textAlign;
-                _verticalAlign = p._verticalAlign;
                 _fontFamily = p._fontFamily;
                 _fontSize = p._fontSize;
                 _fontStyle = p._fontStyle;
@@ -1557,6 +1556,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
                     _textDecoration = p._textDecoration;
                     _top = p._top;
                     _position = p._position;
+                    _verticalAlign = p._verticalAlign;
                     _width = p._width;
                     _maxWidth = p._maxWidth;
                     _wordSpacing = p._wordSpacing;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align

Merging from @monoblaine's fork: https://github.com/monoblaine/HTML-Renderer/commit/a86e02e648c9c067162bffd26e5790aa6194cef6