### PR TITLE
Fixed IndexOutOfRange

### DIFF
--- a/Source/HtmlRenderer/Core/Parse/RegexParserUtils.cs
+++ b/Source/HtmlRenderer/Core/Parse/RegexParserUtils.cs
@@ -107,9 +107,9 @@ namespace TheArtOfDev.HtmlRenderer.Core.Parse
                 int endIdx = stylesheet.IndexOf('{', startIdx);
                 if (endIdx > -1)
                 {
+                    endIdx++; // to prevent IndexOutOfRangeException at line 113. When '}' is last character in 'stylesheet' variable
                     while (count > 0 && endIdx < stylesheet.Length)
                     {
-                        endIdx++;
                         if (stylesheet[endIdx] == '{')
                         {
                             count++;
@@ -118,6 +118,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Parse
                         {
                             count--;
                         }
+                        endIdx++;
                     }
                     if (endIdx < stylesheet.Length)
                     {


### PR DESCRIPTION
When '}' is last character in 'stylesheet' variable

Merge fix by @eocron: https://github.com/eocron/HTML-Renderer/commit/febaef3c4c1eff9b8b98291029c1dba42a4791bb