### PR TITLE
Update PdfGenerator.cs

### DIFF
--- a/Source/HtmlRenderer.PdfSharp/PdfGenerator.cs
+++ b/Source/HtmlRenderer.PdfSharp/PdfGenerator.cs
@@ -218,6 +218,11 @@ namespace TheArtOfDev.HtmlRenderer.PdfSharp
                         {
                             // document links to the same page as the link is not allowed
                             int anchorPageIdx = (int)(anchorRect.Value.Top / pageSize.Height);
+                            
+                            // in case that not find the page index, set to the first page.
+                            if (anchorPageIdx == 0)
+                                anchorPageIdx = 1;
+                            
                             if (i != anchorPageIdx)
                                 document.Pages[i].AddDocumentLink(new PdfRectangle(xRect), anchorPageIdx);
                         }


### PR DESCRIPTION
With one embeded image make an error because anchorPageidx = 0 and it isn't a valid page.

Merge fix by @AndGutierrez: https://github.com/AndGutierrez/HTML-Renderer/commit/4cc9989b98138c08b0f9bc13de5c431ca8ee3a86