### PR TITLE
Fix: Calculate em unit based on font size rather than line height

### DIFF
--- a/Source/HtmlRenderer/Core/Dom/CssBoxProperties.cs
+++ b/Source/HtmlRenderer/Core/Dom/CssBoxProperties.cs
@@ -1432,7 +1432,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Dom
         /// <returns></returns>
         public double GetEmHeight()
         {
-            return ActualFont.Height;
+            return ActualFont.Size * 96d / 72d;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
This PR fixes an issue where the `em` unit was incorrectly calculated using the font's line height (`ActualFont.Height`) instead of the font size. 

## Motivation
I discovered this bug when applying `text-indent: 2em;` to a `<p>` tag. The resulting indentation was noticeably larger than the expected width of two full-width characters. 

The root cause was in `CssBoxProperties.GetEmHeight()`, which returned the line height. By updating the calculation to `ActualFont.Size * 96d / 72d` (converting points to pixels), the `em` unit now matches the actual font size. 

**Before Fix:**
<img width="759" height="504" alt="图片" src="https://github.com/user-attachments/assets/25b3b2a8-1163-4996-9ddb-cc19dbd14c26" />

**After Fix:**
<img width="891" height="428" alt="图片" src="https://github.com/user-attachments/assets/3f560b6e-9510-49b9-bfc6-fbccaabd6744" />

