### PR TITLE
Target .NET 10 for HtmlRenderer.Core and HtmlRenderer.WinForms

### DIFF
--- a/Source/HtmlRenderer.WinForms/Adapters/WinFormsAdapter.cs
+++ b/Source/HtmlRenderer.WinForms/Adapters/WinFormsAdapter.cs
@@ -88,7 +88,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Adapters
             return new BrushAdapter(new LinearGradientBrush(Utils.Convert(rect), Utils.Convert(color1), Utils.Convert(color2), (float)angle), true);
         }
 
-        protected override RImage ConvertImageInt(object image)
+        protected override RImage? ConvertImageInt(object? image)
         {
             return image != null ? new ImageAdapter((Image)image) : null;
         }

--- a/Source/HtmlRenderer.WinForms/HtmlContainer.cs
+++ b/Source/HtmlRenderer.WinForms/HtmlContainer.cs
@@ -286,7 +286,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// Get the currently selected text segment in the html.
         /// </summary>
-        public string SelectedText
+        public string? SelectedText
         {
             get { return _htmlContainerInt.SelectedText; }
         }
@@ -294,7 +294,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// Copy the currently selected html segment with style.
         /// </summary>
-        public string SelectedHtml
+        public string? SelectedHtml
         {
             get { return _htmlContainerInt.SelectedHtml; }
         }
@@ -312,7 +312,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         /// <param name="htmlSource">the html to init with, init empty if not given</param>
         /// <param name="baseCssData">optional: the stylesheet to init with, init default if not given</param>
-        public void SetHtml(string htmlSource, CssData baseCssData = null)
+        public void SetHtml(string? htmlSource, CssData? baseCssData = null)
         {
             _htmlContainerInt.SetHtml(htmlSource, baseCssData);
         }
@@ -322,7 +322,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         /// <param name="styleGen">Optional: controls the way styles are generated when html is generated (default: <see cref="HtmlGenerationStyle.Inline"/>)</param>
         /// <returns>generated html</returns>
-        public string GetHtml(HtmlGenerationStyle styleGen = HtmlGenerationStyle.Inline)
+        public string? GetHtml(HtmlGenerationStyle styleGen = HtmlGenerationStyle.Inline)
         {
             return _htmlContainerInt.GetHtml(styleGen);
         }
@@ -334,7 +334,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <param name="location">the location to find the attribute at</param>
         /// <param name="attribute">the attribute key to get value by</param>
         /// <returns>found attribute value or null if not found</returns>
-        public string GetAttributeAt(Point location, string attribute)
+        public string? GetAttributeAt(Point location, string attribute)
         {
             return _htmlContainerInt.GetAttributeAt(Utils.Convert(location), attribute);
         }
@@ -358,7 +358,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         /// <param name="location">the location to find the link at</param>
         /// <returns>css link href if exists or null</returns>
-        public string GetLinkAt(Point location)
+        public string? GetLinkAt(Point location)
         {
             return _htmlContainerInt.GetLinkAt(Utils.Convert(location));
         }

--- a/Source/HtmlRenderer.WinForms/HtmlLabel.cs
+++ b/Source/HtmlRenderer.WinForms/HtmlLabel.cs
@@ -75,7 +75,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// Underline html container instance.
         /// </summary>
-        protected HtmlContainer _htmlContainer;
+        protected HtmlContainer? _htmlContainer;
 
         /// <summary>
         /// The current border style of the control
@@ -85,17 +85,17 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// the raw base stylesheet data used in the control
         /// </summary>
-        protected string _baseRawCssData;
+        protected string? _baseRawCssData;
 
         /// <summary>
         /// the base stylesheet data used in the panel
         /// </summary>
-        protected CssData _baseCssData;
+        protected CssData? _baseCssData;
 
         /// <summary>
         /// the current html text set in the control
         /// </summary>
-        protected string _text;
+        protected string? _text;
 
         /// <summary>
         /// is to handle auto size of the control height only
@@ -296,7 +296,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         [Description("Set base stylesheet to be used by html rendered in the control.")]
         [Category("Appearance")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Windows.Forms.Design, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Drawing.Design.UITypeEditor, System.Windows.Forms, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
         public virtual string BaseStylesheet
         {
             get { return _baseRawCssData; }
@@ -488,21 +488,17 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         {
             if (_htmlContainer != null)
             {
-                Graphics g = CreateGraphics();
-                if (g != null)
+                using (var g = CreateGraphics())
+                using (var ig = new GraphicsAdapter(g, _htmlContainer.UseGdiPlusTextRendering))
                 {
-                    using (g)
-                    using (var ig = new GraphicsAdapter(g, _htmlContainer.UseGdiPlusTextRendering))
-                    {
-                        var newSize = HtmlRendererUtils.Layout(ig,
+                    var newSize = HtmlRendererUtils.Layout(ig,
                             _htmlContainer.HtmlContainerInt,
                             new RSize(ClientSize.Width - Padding.Horizontal, ClientSize.Height - Padding.Vertical),
                             new RSize(MinimumSize.Width - Padding.Horizontal, MinimumSize.Height - Padding.Vertical),
                             new RSize(MaximumSize.Width - Padding.Horizontal, MaximumSize.Height - Padding.Vertical),
                             AutoSize,
                             AutoSizeHeightOnly);
-                        ClientSize = Utils.ConvertRound(new RSize(newSize.Width + Padding.Horizontal, newSize.Height + Padding.Vertical));
-                    }
+                    ClientSize = Utils.ConvertRound(new RSize(newSize.Width + Padding.Horizontal, newSize.Height + Padding.Vertical));
                 }
             }
             base.OnLayout(levent);
@@ -659,7 +655,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                 try
                 {
                     // Replace .NET's hand cursor with the OS cursor
-                    Win32Utils.SetCursor(Win32Utils.LoadCursor(0, Win32Utils.IdcHand));
+                    Win32Utils.SetCursor(Win32Utils.LoadCursor(IntPtr.Zero, Win32Utils.IdcHand));
                     m.Result = IntPtr.Zero;
                     return;
                 }

--- a/Source/HtmlRenderer.WinForms/HtmlPanel.cs
+++ b/Source/HtmlRenderer.WinForms/HtmlPanel.cs
@@ -77,17 +77,17 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// the raw base stylesheet data used in the control
         /// </summary>
-        protected string _baseRawCssData;
+        protected string? _baseRawCssData;
 
         /// <summary>
         /// the base stylesheet data used in the control
         /// </summary>
-        protected CssData _baseCssData;
+        protected CssData? _baseCssData;
 
         /// <summary>
         /// the current html text set in the control
         /// </summary>
-        protected string _text;
+        protected string? _text;
 
         /// <summary>
         /// If to use cursors defined by the operating system or .NET cursors
@@ -304,7 +304,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         [Category("Appearance")]
         [Description("Set base stylesheet to be used by html rendered in the control.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Windows.Forms.Design, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Drawing.Design.UITypeEditor, System.Windows.Forms, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
         public virtual string BaseStylesheet
         {
             get { return _baseRawCssData; }
@@ -471,13 +471,9 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
             {
                 _htmlContainer.MaxSize = new SizeF(ClientSize.Width - Padding.Horizontal, 0);
 
-                Graphics g = CreateGraphics();
-                if (g != null)
+                using (var g = CreateGraphics())
                 {
-                    using (g)
-                    {
-                        _htmlContainer.PerformLayout(g);
-                    }
+                    _htmlContainer.PerformLayout(g);
                 }
 
                 AutoScrollMinSize = Size.Round(new SizeF(_htmlContainer.ActualSize.Width + Padding.Horizontal, _htmlContainer.ActualSize.Height));
@@ -747,7 +743,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                 try
                 {
                     // Replace .NET's hand cursor with the OS cursor
-                    Win32Utils.SetCursor(Win32Utils.LoadCursor(0, Win32Utils.IdcHand));
+                    Win32Utils.SetCursor(Win32Utils.LoadCursor(IntPtr.Zero, Win32Utils.IdcHand));
                     m.Result = IntPtr.Zero;
                     return;
                 }

--- a/Source/HtmlRenderer.WinForms/HtmlRenderer.WinForms.csproj
+++ b/Source/HtmlRenderer.WinForms/HtmlRenderer.WinForms.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>TheArtOfDev.HtmlRenderer.WinForms</RootNamespace>
     <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
 	<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-	<EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <!-- NuGet Package Properties -->
   <PropertyGroup>

--- a/Source/HtmlRenderer.WinForms/HtmlToolTip.cs
+++ b/Source/HtmlRenderer.WinForms/HtmlToolTip.cs
@@ -31,17 +31,17 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// the container to render and handle the html shown in the tooltip
         /// </summary>
-        protected HtmlContainer _htmlContainer;
+        protected HtmlContainer? _htmlContainer;
 
         /// <summary>
         /// the raw base stylesheet data used in the control
         /// </summary>
-        protected string _baseRawCssData;
+        protected string? _baseRawCssData;
 
         /// <summary>
         /// the base stylesheet data used in the panel
         /// </summary>
-        protected CssData _baseCssData;
+        protected CssData? _baseCssData;
 
         /// <summary>
         /// The text rendering hint to be used for text rendering.
@@ -57,13 +57,13 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// the control that the tooltip is currently showing on.<br/>
         /// Used for link handling.
         /// </summary>
-        private Control _associatedControl;
+        private Control? _associatedControl;
 
         /// <summary>
         /// timer used to handle mouse move events when mouse is over the tooltip.<br/>
         /// Used for link handling.
         /// </summary>
-        private Timer _linkHandlingTimer;
+        private Timer? _linkHandlingTimer;
 
         /// <summary>
         /// the handle of the actual tooltip window used to know when the tooltip is hidden<br/>
@@ -175,7 +175,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         [Description("Set base stylesheet to be used by html rendered in the tooltip.")]
         [Category("Appearance")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Windows.Forms.Design, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Drawing.Design.UITypeEditor, System.Windows.Forms, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
         public virtual string BaseStylesheet
         {
             get { return _baseRawCssData; }
@@ -238,6 +238,9 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         protected virtual void OnToolTipPopup(PopupEventArgs e)
         {
+            if (e.AssociatedControl == null)
+                return;
+
             //Create fragment container
             var cssClass = string.IsNullOrEmpty(_tooltipCssClass) ? null : string.Format(" class=\"{0}\"", _tooltipCssClass);
             var toolipHtml = string.Format("<div{0}>{1}</div>", cssClass, GetToolTip(e.AssociatedControl));
@@ -276,7 +279,8 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                 _tooltipHandle = Win32Utils.WindowFromDC(hdc);
                 e.Graphics.ReleaseHdc(hdc);
 
-                AdjustTooltipPosition(e.AssociatedControl, e.Bounds.Size);
+                if (e.AssociatedControl != null)
+                    AdjustTooltipPosition(e.AssociatedControl, e.Bounds.Size);
             }
 
             e.Graphics.Clear(Color.White);
@@ -373,16 +377,19 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                     _linkHandlingTimer.Stop();
                     _tooltipHandle = IntPtr.Zero;
 
-                    var mPos = Control.MousePosition;
-                    var mButtons = Control.MouseButtons;
-                    var rect = Win32Utils.GetWindowRectangle(handle);
-                    if (rect.Contains(mPos))
+                    if (handle != IntPtr.Zero && _associatedControl != null)
                     {
-                        if (mButtons == MouseButtons.Left)
+                        var mPos = Control.MousePosition;
+                        var mButtons = Control.MouseButtons;
+                        var rect = Win32Utils.GetWindowRectangle(handle);
+                        if (rect.Contains(mPos))
                         {
-                            var args = new MouseEventArgs(mButtons, 1, mPos.X - rect.X, mPos.Y - rect.Y, 0);
-                            _htmlContainer.HandleMouseDown(_associatedControl, args);
-                            _htmlContainer.HandleMouseUp(_associatedControl, args);
+                            if (mButtons == MouseButtons.Left)
+                            {
+                                var args = new MouseEventArgs(mButtons, 1, mPos.X - rect.X, mPos.Y - rect.Y, 0);
+                                _htmlContainer.HandleMouseDown(_associatedControl, args);
+                                _htmlContainer.HandleMouseUp(_associatedControl, args);
+                            }
                         }
                     }
                 }
@@ -402,22 +409,21 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
             Draw -= OnToolTipDraw;
             Disposed -= OnToolTipDisposed;
 
+            if (_linkHandlingTimer != null)
+            {
+                _linkHandlingTimer.Tick -= OnLinkHandlingTimerTick;
+                _linkHandlingTimer.Dispose();
+                _linkHandlingTimer = null;
+            }
+
             if (_htmlContainer != null)
             {
+                _htmlContainer.LinkClicked -= OnLinkClicked;
                 _htmlContainer.RenderError -= OnRenderError;
                 _htmlContainer.StylesheetLoad -= OnStylesheetLoad;
                 _htmlContainer.ImageLoad -= OnImageLoad;
                 _htmlContainer.Dispose();
                 _htmlContainer = null;
-            }
-
-            if (_linkHandlingTimer != null)
-            {
-                _linkHandlingTimer.Dispose();
-                _linkHandlingTimer = null;
-
-                if (_htmlContainer != null)
-                    _htmlContainer.LinkClicked -= OnLinkClicked;
             }
         }
 

--- a/Source/HtmlRenderer.WinForms/MetafileExtensions.cs
+++ b/Source/HtmlRenderer.WinForms/MetafileExtensions.cs
@@ -14,24 +14,25 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                 by : SWAT Team member _1 
                 Date : Friday, February 01, 2008 1:38 PM 
                 */
-            int enfMetafileHandle = me.GetHenhmetafile().ToInt32();
+            IntPtr enfMetafileHandle = me.GetHenhmetafile();
             int bufferSize = GetEnhMetaFileBits(enfMetafileHandle, 0, null); // Get required buffer size.  
             byte[] buffer = new byte[bufferSize]; // Allocate sufficient buffer  
             if (GetEnhMetaFileBits(enfMetafileHandle, bufferSize, buffer) <= 0) // Get raw metafile data.  
                 throw new SystemException("Fail");
 
-            FileStream ms = File.Open(fileName, FileMode.Create);
-            ms.Write(buffer, 0, bufferSize);
-            ms.Close();
-            ms.Dispose();
+            using (var ms = File.Open(fileName, FileMode.Create))
+            {
+                ms.Write(buffer, 0, bufferSize);
+            }
+
             if (!DeleteEnhMetaFile(enfMetafileHandle)) //free handle  
                 throw new SystemException("Fail Free");
         }
 
-        [DllImport("gdi32")]
-        public static extern int GetEnhMetaFileBits(int hemf, int cbBuffer, byte[] lpbBuffer);
+        [DllImport("gdi32.dll")]
+        public static extern int GetEnhMetaFileBits(IntPtr hemf, int cbBuffer, byte[] lpbBuffer);
 
-        [DllImport("gdi32")]
-        public static extern bool DeleteEnhMetaFile(int hemfbitHandle);
+        [DllImport("gdi32.dll")]
+        public static extern bool DeleteEnhMetaFile(IntPtr hemfbitHandle);
     }  
 }

--- a/Source/HtmlRenderer.WinForms/Utilities/Utils.cs
+++ b/Source/HtmlRenderer.WinForms/Utilities/Utils.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Drawing;
 using TheArtOfDev.HtmlRenderer.Adapters.Entities;
+using TheArtOfDev.HtmlRenderer.Core.Utils;
 
 namespace TheArtOfDev.HtmlRenderer.WinForms.Utilities
 {
@@ -34,6 +35,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Utilities
         /// </summary>
         public static PointF[] Convert(RPoint[] points)
         {
+            ArgChecker.AssertArgNotNull(points, nameof(points));
             PointF[] myPoints = new PointF[points.Length];
             for (int i = 0; i < points.Length; i++)
                 myPoints[i] = Convert(points[i]);

--- a/Source/HtmlRenderer.WinForms/Utilities/Win32Utils.cs
+++ b/Source/HtmlRenderer.WinForms/Utilities/Win32Utils.cs
@@ -47,11 +47,11 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Utilities
 
         public const int TextAlignBaselineRtl = 256 + 24;
 
-        [DllImport("user32.dll")]
-        public static extern int SetCursor(int hCursor);
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr SetCursor(IntPtr hCursor);
 
-        [DllImport("user32.dll")]
-        public static extern int LoadCursor(int hInstance, int lpCursorName);
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr LoadCursor(IntPtr hInstance, int lpCursorName);
 
         /// <summary>
         /// Create a compatible memory HDC from the given HDC.<br/>

--- a/Source/HtmlRenderer/Adapters/Entities/RColor.cs
+++ b/Source/HtmlRenderer/Adapters/Entities/RColor.cs
@@ -211,7 +211,7 @@ namespace TheArtOfDev.HtmlRenderer.Adapters.Entities
         /// </returns>
         /// <param name="obj">The object to test. </param>
         /// <filterpriority>1</filterpriority>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is RColor)
             {

--- a/Source/HtmlRenderer/Adapters/Entities/RPoint.cs
+++ b/Source/HtmlRenderer/Adapters/Entities/RPoint.cs
@@ -251,7 +251,7 @@ namespace TheArtOfDev.HtmlRenderer.Adapters.Entities
         ///     The <see cref="T:System.Object" /> to test.
         /// </param>
         /// <filterpriority>1</filterpriority>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is RPoint))
                 return false;

--- a/Source/HtmlRenderer/Adapters/Entities/RRect.cs
+++ b/Source/HtmlRenderer/Adapters/Entities/RRect.cs
@@ -284,7 +284,7 @@ namespace TheArtOfDev.HtmlRenderer.Adapters.Entities
         /// <param name="obj">
         ///     The <see cref="T:System.Object" /> to test.
         /// </param>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is RRect))
                 return false;

--- a/Source/HtmlRenderer/Adapters/Entities/RSize.cs
+++ b/Source/HtmlRenderer/Adapters/Entities/RSize.cs
@@ -287,7 +287,7 @@ namespace TheArtOfDev.HtmlRenderer.Adapters.Entities
         ///     The <see cref="T:System.Object" /> to test.
         /// </param>
         /// <filterpriority>1</filterpriority>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is RSize))
                 return false;

--- a/Source/HtmlRenderer/Adapters/RAdapter.cs
+++ b/Source/HtmlRenderer/Adapters/RAdapter.cs
@@ -365,7 +365,7 @@ namespace TheArtOfDev.HtmlRenderer.Adapters
         /// </summary>
         /// <param name="image">the image returned from load event</param>
         /// <returns>converted image or null</returns>
-        protected abstract RImage ConvertImageInt(object image);
+        protected abstract RImage? ConvertImageInt(object? image);
 
         /// <summary>
         /// Create an <see cref="RImage"/> object from the given stream.

--- a/Source/HtmlRenderer/Core/Entities/CssBlock.cs
+++ b/Source/HtmlRenderer/Core/Entities/CssBlock.cs
@@ -196,7 +196,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Entities
         /// </summary>
         /// <param name="obj">the other block to compare to</param>
         /// <returns>true - the two blocks are the same, false - otherwise</returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
                 return false;

--- a/Source/HtmlRenderer/Core/Handlers/ImageDownloader.cs
+++ b/Source/HtmlRenderer/Core/Handlers/ImageDownloader.cs
@@ -39,9 +39,14 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
     internal sealed class ImageDownloader : IDisposable
     {
         /// <summary>
-        /// the web client used to download image from URL (to cancel on dispose)
+        /// List of web clients used to download images (to allow cancel on dispose).
         /// </summary>
         private readonly List<WebClient> _clients = new List<WebClient>();
+
+        /// <summary>
+        /// Lock object for thread-safe _clients access.
+        /// </summary>
+        private readonly object _clientsLock = new object();
 
         /// <summary>
         /// dictionary of image cache path to callbacks of download to handle multiple requests to download the same image 
@@ -111,7 +116,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
             {
                 using (var client = new WebClient())
                 {
-                    _clients.Add(client);
+                    lock (_clientsLock) { _clients.Add(client); }
                     client.DownloadFile(source, tempPath);
                     OnDownloadImageCompleted(client, source, tempPath, filePath, null, false);
                 }
@@ -133,7 +138,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
             try
             {
                 var client = new WebClient();
-                _clients.Add(client);
+                lock (_clientsLock) { _clients.Add(client); }
                 client.DownloadFileCompleted += OnDownloadImageAsyncCompleted;
                 client.DownloadFileAsync(downloadData._uri, downloadData._tempPath, downloadData);
             }
@@ -226,17 +231,20 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
         private void ReleaseObjects()
         {
             _imageDownloadCallbacks.Clear();
-            while (_clients.Count > 0)
+            lock (_clientsLock)
             {
-                try
+                while (_clients.Count > 0)
                 {
-                    var client = _clients[0];
-                    client.CancelAsync();
-                    client.Dispose();
-                    _clients.RemoveAt(0);
+                    try
+                    {
+                        var client = _clients[0];
+                        client.CancelAsync();
+                        client.Dispose();
+                        _clients.RemoveAt(0);
+                    }
+                    catch
+                    { }
                 }
-                catch
-                { }
             }
         }
 

--- a/Source/HtmlRenderer/Core/Handlers/ImageLoadHandler.cs
+++ b/Source/HtmlRenderer/Core/Handlers/ImageLoadHandler.cs
@@ -55,6 +55,11 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
         private readonly ActionInt<RImage, RRect, bool> _loadCompleteCallback;
 
         /// <summary>
+        /// Dedicated lock object (instead of locking on the callback delegate).
+        /// </summary>
+        private readonly object _syncLock = new object();
+
+        /// <summary>
         /// Must be open as long as the image is in use
         /// </summary>
         private FileStream _imageFileStream;
@@ -302,7 +307,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
             try
             {
                 var imageFileStream = File.Open(source, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                lock (_loadCompleteCallback)
+                lock (_syncLock)
                 {
                     _imageFileStream = imageFileStream;
                     if (!_disposed)

--- a/Source/HtmlRenderer/Core/HtmlContainerInt.cs
+++ b/Source/HtmlRenderer/Core/HtmlContainerInt.cs
@@ -460,7 +460,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// <summary>
         /// Get the currently selected text segment in the html.
         /// </summary>
-        public string SelectedText
+        public string? SelectedText
         {
             get { return _selectionHandler.GetSelectedText(); }
         }
@@ -468,7 +468,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// <summary>
         /// Copy the currently selected html segment with style.
         /// </summary>
-        public string SelectedHtml
+        public string? SelectedHtml
         {
             get { return _selectionHandler.GetSelectedHtml(); }
         }
@@ -504,7 +504,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// </summary>
         /// <param name="htmlSource">the html to init with, init empty if not given</param>
         /// <param name="baseCssData">optional: the stylesheet to init with, init default if not given</param>
-        public void SetHtml(string htmlSource, CssData baseCssData = null)
+        public void SetHtml(string? htmlSource, CssData? baseCssData = null)
         {
             Clear();
             if (!string.IsNullOrEmpty(htmlSource))
@@ -561,7 +561,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// </summary>
         /// <param name="styleGen">Optional: controls the way styles are generated when html is generated (default: <see cref="HtmlGenerationStyle.Inline"/>)</param>
         /// <returns>generated html</returns>
-        public string GetHtml(HtmlGenerationStyle styleGen = HtmlGenerationStyle.Inline)
+        public string? GetHtml(HtmlGenerationStyle styleGen = HtmlGenerationStyle.Inline)
         {
             return DomUtils.GenerateHtml(_root, styleGen);
         }
@@ -573,7 +573,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// <param name="location">the location to find the attribute at</param>
         /// <param name="attribute">the attribute key to get value by</param>
         /// <returns>found attribute value or null if not found</returns>
-        public string GetAttributeAt(RPoint location, string attribute)
+        public string? GetAttributeAt(RPoint location, string attribute)
         {
             ArgChecker.AssertArgNotNullOrEmpty(attribute, "attribute");
 
@@ -603,7 +603,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// </summary>
         /// <param name="location">the location to find the link at</param>
         /// <returns>css link href if exists or null</returns>
-        public string GetLinkAt(RPoint location)
+        public string? GetLinkAt(RPoint location)
         {
             var link = DomUtils.GetLinkBox(_root, OffsetByScroll(location));
             return link != null ? link.HrefLink : null;

--- a/Source/HtmlRenderer/HtmlRenderer.csproj
+++ b/Source/HtmlRenderer/HtmlRenderer.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>TheArtOfDev.HtmlRenderer</RootNamespace>
+    <Nullable>enable</Nullable>
 	<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-	<EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <!-- NuGet Package Properties -->
   <PropertyGroup>

--- a/Source/HtmlRenderer/HtmlRenderer.csproj
+++ b/Source/HtmlRenderer/HtmlRenderer.csproj
@@ -26,6 +26,6 @@ For existing implementations see: HtmlRenderer.WinForms, HtmlRenderer.WPF and Ht
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="System.Resources.Extensions" Version="10.0.1" />
+	<PackageReference Include="System.Resources.Extensions" Version="10.0.10" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Modernizes **HtmlRenderer.Core** and **HtmlRenderer.WinForms** for **.NET 10**, with related safety and API fixes.

### Targeting
- **Core**: `net10.0` (was `netstandard2.0;net8.0`)
- **WinForms**: `net10.0-windows` with `UseWindowsForms` + `Nullable`
- Package bump: `System.Resources.Extensions` → 10.0.10

### Bug / safety fixes
- 64-bit-safe P/Invoke for Metafile EMF save and cursor handles (`IntPtr` instead of truncated `int`)
- Thread-safe `ImageDownloader` client list + dedicated lock in `ImageLoadHandler`
- `HtmlToolTip` dispose unsubscription order + null/handle guards
- Nullable annotations on key public APIs (`SetHtml`, selection getters, entity `Equals`)
- Modern WinForms designer `Editor` attribute assembly names for .NET 10

### Breaking change
This drops multi-targeting for Core (`netstandard2.0` / `net8.0`). Consumers on older TFMs need to multi-target or stay on a previous release. Happy to adjust to multi-target (`net8.0` + `net10.0`) if preferred.

### Scope
Only Core + WinForms (no WPF / PdfSharp / Demo changes).

### Test plan
- [x] `dotnet build -c Release` HtmlRenderer.csproj (`net10.0`)
- [x] `dotnet build -c Release` HtmlRenderer.WinForms.csproj (`net10.0-windows`)
- [x] Load assemblies and instantiate `HtmlPanel` / `HtmlContainer.SetHtml(null)`

### Notes
Rebased onto current `master` (includes upstream dependency + GHA updates).
A follow-up PR will add HtmlPanel zoom/pan as a separate feature.