### PR TITLE
HtmlPanel: Ctrl+wheel zoom and middle-button pan

### DIFF
--- a/Source/HtmlRenderer.WinForms/Adapters/GraphicsAdapter.cs
+++ b/Source/HtmlRenderer.WinForms/Adapters/GraphicsAdapter.cs
@@ -63,6 +63,12 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Adapters
         private readonly bool _useGdiPlusTextRendering;
 
         /// <summary>
+        /// True when <see cref="_g"/> has a non-identity world transform (e.g. zoom ScaleTransform).
+        /// GDI TextOut ignores the GDI+ world transform, so drawing must use GDI+ in that case.
+        /// </summary>
+        private readonly bool _hasWorldTransform;
+
+        /// <summary>
         /// the initialized HDC used
         /// </summary>
         private IntPtr _hdc;
@@ -105,7 +111,13 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Adapters
             _g = g;
             _releaseGraphics = releaseGraphics;
 
-            _useGdiPlusTextRendering = useGdiPlusTextRendering;
+            // When a world transform is active (HtmlPanel zoom), force GDI+ for DrawString so text scales.
+            // Layout measurement still prefers GDI when requested (transform is identity on layout Graphics).
+            using (var transform = g.Transform)
+            {
+                _hasWorldTransform = !transform.IsIdentity;
+            }
+            _useGdiPlusTextRendering = useGdiPlusTextRendering || _hasWorldTransform;
         }
 
         public override void PopClip()
@@ -148,7 +160,9 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Adapters
 
         public override RSize MeasureString(string str, RFont font)
         {
-            if (_useGdiPlusTextRendering)
+            // Prefer GDI metrics when layout has no world transform, even if draw uses GDI+ for zoom.
+            // Measuring with an active ScaleTransform would inflate sizes and break layout.
+            if (_useGdiPlusTextRendering && !_hasWorldTransform)
             {
                 ReleaseHdc();
                 var fontAdapter = (FontAdapter)font;
@@ -187,7 +201,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Adapters
         {
             charFit = 0;
             charFitWidth = 0;
-            if (_useGdiPlusTextRendering)
+            if (_useGdiPlusTextRendering && !_hasWorldTransform)
             {
                 ReleaseHdc();
 
@@ -216,7 +230,8 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Adapters
 
         public override void DrawString(string str, RFont font, RColor color, RPoint point, RSize size, bool rtl)
         {
-            if (_useGdiPlusTextRendering)
+            // GDI TextOut ignores Graphics.ScaleTransform; use GDI+ whenever a world transform is active (zoom).
+            if (_useGdiPlusTextRendering || _hasWorldTransform)
             {
                 ReleaseHdc();
                 SetRtlAlignGdiPlus(rtl);

--- a/Source/HtmlRenderer.WinForms/Adapters/WinFormsAdapter.cs
+++ b/Source/HtmlRenderer.WinForms/Adapters/WinFormsAdapter.cs
@@ -88,7 +88,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Adapters
             return new BrushAdapter(new LinearGradientBrush(Utils.Convert(rect), Utils.Convert(color1), Utils.Convert(color2), (float)angle), true);
         }
 
-        protected override RImage ConvertImageInt(object image)
+        protected override RImage? ConvertImageInt(object? image)
         {
             return image != null ? new ImageAdapter((Image)image) : null;
         }

--- a/Source/HtmlRenderer.WinForms/HtmlContainer.cs
+++ b/Source/HtmlRenderer.WinForms/HtmlContainer.cs
@@ -286,7 +286,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// Get the currently selected text segment in the html.
         /// </summary>
-        public string SelectedText
+        public string? SelectedText
         {
             get { return _htmlContainerInt.SelectedText; }
         }
@@ -294,7 +294,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// Copy the currently selected html segment with style.
         /// </summary>
-        public string SelectedHtml
+        public string? SelectedHtml
         {
             get { return _htmlContainerInt.SelectedHtml; }
         }
@@ -312,7 +312,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         /// <param name="htmlSource">the html to init with, init empty if not given</param>
         /// <param name="baseCssData">optional: the stylesheet to init with, init default if not given</param>
-        public void SetHtml(string htmlSource, CssData baseCssData = null)
+        public void SetHtml(string? htmlSource, CssData? baseCssData = null)
         {
             _htmlContainerInt.SetHtml(htmlSource, baseCssData);
         }
@@ -322,7 +322,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         /// <param name="styleGen">Optional: controls the way styles are generated when html is generated (default: <see cref="HtmlGenerationStyle.Inline"/>)</param>
         /// <returns>generated html</returns>
-        public string GetHtml(HtmlGenerationStyle styleGen = HtmlGenerationStyle.Inline)
+        public string? GetHtml(HtmlGenerationStyle styleGen = HtmlGenerationStyle.Inline)
         {
             return _htmlContainerInt.GetHtml(styleGen);
         }
@@ -334,7 +334,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <param name="location">the location to find the attribute at</param>
         /// <param name="attribute">the attribute key to get value by</param>
         /// <returns>found attribute value or null if not found</returns>
-        public string GetAttributeAt(Point location, string attribute)
+        public string? GetAttributeAt(Point location, string attribute)
         {
             return _htmlContainerInt.GetAttributeAt(Utils.Convert(location), attribute);
         }
@@ -358,7 +358,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         /// <param name="location">the location to find the link at</param>
         /// <returns>css link href if exists or null</returns>
-        public string GetLinkAt(Point location)
+        public string? GetLinkAt(Point location)
         {
             return _htmlContainerInt.GetLinkAt(Utils.Convert(location));
         }

--- a/Source/HtmlRenderer.WinForms/HtmlLabel.cs
+++ b/Source/HtmlRenderer.WinForms/HtmlLabel.cs
@@ -75,7 +75,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// Underline html container instance.
         /// </summary>
-        protected HtmlContainer _htmlContainer;
+        protected HtmlContainer? _htmlContainer;
 
         /// <summary>
         /// The current border style of the control
@@ -85,17 +85,17 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// the raw base stylesheet data used in the control
         /// </summary>
-        protected string _baseRawCssData;
+        protected string? _baseRawCssData;
 
         /// <summary>
         /// the base stylesheet data used in the panel
         /// </summary>
-        protected CssData _baseCssData;
+        protected CssData? _baseCssData;
 
         /// <summary>
         /// the current html text set in the control
         /// </summary>
-        protected string _text;
+        protected string? _text;
 
         /// <summary>
         /// is to handle auto size of the control height only
@@ -296,7 +296,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         [Description("Set base stylesheet to be used by html rendered in the control.")]
         [Category("Appearance")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Windows.Forms.Design, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Drawing.Design.UITypeEditor, System.Windows.Forms, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
         public virtual string BaseStylesheet
         {
             get { return _baseRawCssData; }
@@ -488,21 +488,17 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         {
             if (_htmlContainer != null)
             {
-                Graphics g = CreateGraphics();
-                if (g != null)
+                using (var g = CreateGraphics())
+                using (var ig = new GraphicsAdapter(g, _htmlContainer.UseGdiPlusTextRendering))
                 {
-                    using (g)
-                    using (var ig = new GraphicsAdapter(g, _htmlContainer.UseGdiPlusTextRendering))
-                    {
-                        var newSize = HtmlRendererUtils.Layout(ig,
+                    var newSize = HtmlRendererUtils.Layout(ig,
                             _htmlContainer.HtmlContainerInt,
                             new RSize(ClientSize.Width - Padding.Horizontal, ClientSize.Height - Padding.Vertical),
                             new RSize(MinimumSize.Width - Padding.Horizontal, MinimumSize.Height - Padding.Vertical),
                             new RSize(MaximumSize.Width - Padding.Horizontal, MaximumSize.Height - Padding.Vertical),
                             AutoSize,
                             AutoSizeHeightOnly);
-                        ClientSize = Utils.ConvertRound(new RSize(newSize.Width + Padding.Horizontal, newSize.Height + Padding.Vertical));
-                    }
+                    ClientSize = Utils.ConvertRound(new RSize(newSize.Width + Padding.Horizontal, newSize.Height + Padding.Vertical));
                 }
             }
             base.OnLayout(levent);
@@ -659,7 +655,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                 try
                 {
                     // Replace .NET's hand cursor with the OS cursor
-                    Win32Utils.SetCursor(Win32Utils.LoadCursor(0, Win32Utils.IdcHand));
+                    Win32Utils.SetCursor(Win32Utils.LoadCursor(IntPtr.Zero, Win32Utils.IdcHand));
                     m.Result = IntPtr.Zero;
                     return;
                 }

--- a/Source/HtmlRenderer.WinForms/HtmlPanel.cs
+++ b/Source/HtmlRenderer.WinForms/HtmlPanel.cs
@@ -77,17 +77,17 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// the raw base stylesheet data used in the control
         /// </summary>
-        protected string _baseRawCssData;
+        protected string? _baseRawCssData;
 
         /// <summary>
         /// the base stylesheet data used in the control
         /// </summary>
-        protected CssData _baseCssData;
+        protected CssData? _baseCssData;
 
         /// <summary>
         /// the current html text set in the control
         /// </summary>
-        protected string _text;
+        protected string? _text;
 
         /// <summary>
         /// If to use cursors defined by the operating system or .NET cursors
@@ -304,7 +304,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         [Category("Appearance")]
         [Description("Set base stylesheet to be used by html rendered in the control.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Windows.Forms.Design, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Drawing.Design.UITypeEditor, System.Windows.Forms, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
         public virtual string BaseStylesheet
         {
             get { return _baseRawCssData; }
@@ -471,13 +471,9 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
             {
                 _htmlContainer.MaxSize = new SizeF(ClientSize.Width - Padding.Horizontal, 0);
 
-                Graphics g = CreateGraphics();
-                if (g != null)
+                using (var g = CreateGraphics())
                 {
-                    using (g)
-                    {
-                        _htmlContainer.PerformLayout(g);
-                    }
+                    _htmlContainer.PerformLayout(g);
                 }
 
                 AutoScrollMinSize = Size.Round(new SizeF(_htmlContainer.ActualSize.Width + Padding.Horizontal, _htmlContainer.ActualSize.Height));
@@ -747,7 +743,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                 try
                 {
                     // Replace .NET's hand cursor with the OS cursor
-                    Win32Utils.SetCursor(Win32Utils.LoadCursor(0, Win32Utils.IdcHand));
+                    Win32Utils.SetCursor(Win32Utils.LoadCursor(IntPtr.Zero, Win32Utils.IdcHand));
                     m.Result = IntPtr.Zero;
                     return;
                 }

--- a/Source/HtmlRenderer.WinForms/HtmlPanel.cs
+++ b/Source/HtmlRenderer.WinForms/HtmlPanel.cs
@@ -59,6 +59,12 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
     /// <h4>RenderError event:</h4>
     /// Raised when an error occurred during html rendering.<br/>
     /// </para>
+    /// <para>
+    /// <h4>Zoom and pan:</h4>
+    /// Ctrl+MouseWheel zooms the content with anchor-to-cursor behavior (also Ctrl+/− and Ctrl+0).<br/>
+    /// Middle-mouse button drag pans the canvas via scroll position.<br/>
+    /// See <see cref="Zoom"/> for programmatic control.
+    /// </para>
     /// </summary>
     public class HtmlPanel : ScrollableControl
     {
@@ -104,6 +110,41 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         protected Point _lastScrollOffset;
 
+        /// <summary>
+        /// The zoom factor of the rendered HTML (1.0 = 100%).
+        /// </summary>
+        protected float _zoom = 1f;
+
+        /// <summary>
+        /// True while middle-mouse button pan is active.
+        /// </summary>
+        private bool _isPanning;
+
+        /// <summary>
+        /// Last client mouse position during middle-mouse pan.
+        /// </summary>
+        private Point _panLastPoint;
+
+        /// <summary>
+        /// Cursor to restore when middle-mouse pan ends.
+        /// </summary>
+        private Cursor? _cursorBeforePan;
+
+        /// <summary>
+        /// Minimum allowed zoom factor.
+        /// </summary>
+        private const float MinZoom = 0.25f;
+
+        /// <summary>
+        /// Maximum allowed zoom factor.
+        /// </summary>
+        private const float MaxZoom = 5f;
+
+        /// <summary>
+        /// Zoom change per Ctrl+wheel / Ctrl+/- step.
+        /// </summary>
+        private const float ZoomStep = 0.1f;
+
         #endregion
 
 
@@ -133,6 +174,12 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         [Category("Property Changed")]
         public event EventHandler BorderStyleChanged;
+
+        /// <summary>
+        /// Raised when the <see cref="Zoom"/> property value changes.
+        /// </summary>
+        [Category("Property Changed")]
+        public event EventHandler ZoomChanged;
 
         /// <summary>
         /// Raised when the set html document has been fully loaded.<br/>
@@ -245,6 +292,19 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         {
             get { return _useSystemCursors; }
             set { _useSystemCursors = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the zoom factor of the rendered HTML (1.0 = 100%).<br/>
+        /// Values are clamped to the range 0.25–5.0. Setting this property anchors zoom to the viewport center.
+        /// </summary>
+        [Category("Behavior")]
+        [DefaultValue(1f)]
+        [Description("The zoom factor of the rendered HTML (1.0 = 100%).")]
+        public virtual float Zoom
+        {
+            get { return _zoom; }
+            set { SetZoom(value, null); }
         }
 
         /// <summary>
@@ -404,8 +464,9 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                 var rect = _htmlContainer.GetElementRectangle(elementId);
                 if (rect.HasValue)
                 {
-                    UpdateScroll(Point.Round(rect.Value.Location));
-                    _htmlContainer.HandleMouseMove(this, new MouseEventArgs(MouseButtons, 0, MousePosition.X, MousePosition.Y, 0));
+                    var location = rect.Value.Location;
+                    UpdateScroll(Point.Round(new PointF(location.X * _zoom, location.Y * _zoom)));
+                    InvokeMouseMove();
                 }
             }
         }
@@ -417,6 +478,55 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         {
             if (_htmlContainer != null)
                 _htmlContainer.ClearSelection();
+        }
+
+        /// <summary>
+        /// Set the zoom factor, optionally anchoring the scroll so the document point under
+        /// <paramref name="anchorClientPoint"/> stays fixed on screen (browser-style zoom).
+        /// </summary>
+        /// <param name="zoom">desired zoom factor (clamped to 0.25–5.0)</param>
+        /// <param name="anchorClientPoint">client-space anchor; null uses the viewport center</param>
+        public virtual void SetZoom(float zoom, Point? anchorClientPoint)
+        {
+            float z1 = Math.Max(MinZoom, Math.Min(MaxZoom, zoom));
+            if (Math.Abs(z1 - _zoom) < 0.0001f)
+                return;
+
+            float z0 = _zoom;
+            Point anchor = anchorClientPoint ?? new Point(ClientSize.Width / 2, ClientSize.Height / 2);
+
+            // AutoScrollPosition is negative when scrolled; convert anchor to logical document coords
+            double docX = (anchor.X - AutoScrollPosition.X) / z0;
+            double docY = (anchor.Y - AutoScrollPosition.Y) / z0;
+
+            _zoom = z1;
+            PerformLayout();
+
+            // Keep the same document point under the anchor after zoom
+            int scrollX = (int)Math.Round(docX * z1 - anchor.X);
+            int scrollY = (int)Math.Round(docY * z1 - anchor.Y);
+            scrollX = ClampScroll(scrollX, AutoScrollMinSize.Width, ClientSize.Width);
+            scrollY = ClampScroll(scrollY, AutoScrollMinSize.Height, ClientSize.Height);
+            AutoScrollPosition = new Point(scrollX, scrollY);
+            SyncHtmlScrollOffset();
+            Invalidate();
+            OnZoomChanged(EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Increase zoom by one step, anchored at the given client point (or viewport center).
+        /// </summary>
+        public void ZoomIn(Point? anchorClientPoint = null)
+        {
+            SetZoom(_zoom + ZoomStep, anchorClientPoint);
+        }
+
+        /// <summary>
+        /// Decrease zoom by one step, anchored at the given client point (or viewport center).
+        /// </summary>
+        public void ZoomOut(Point? anchorClientPoint = null)
+        {
+            SetZoom(_zoom - ZoomStep, anchorClientPoint);
         }
 
         #region Private methods
@@ -455,7 +565,8 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
             base.OnLayout(levent);
 
             // to handle if vertical scrollbar is appearing or disappearing
-            if (_htmlContainer != null && Math.Abs(_htmlContainer.MaxSize.Width - ClientSize.Width) > 0.1)
+            float layoutWidth = (ClientSize.Width - Padding.Horizontal) / _zoom;
+            if (_htmlContainer != null && Math.Abs(_htmlContainer.MaxSize.Width - layoutWidth) > 0.1)
             {
                 PerformHtmlLayout();
                 base.OnLayout(levent);
@@ -463,20 +574,22 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         }
 
         /// <summary>
-        /// Perform html container layout by the current panel client size.
+        /// Perform html container layout by the current panel client size and zoom.
         /// </summary>
         protected void PerformHtmlLayout()
         {
             if (_htmlContainer != null)
             {
-                _htmlContainer.MaxSize = new SizeF(ClientSize.Width - Padding.Horizontal, 0);
+                _htmlContainer.MaxSize = new SizeF((ClientSize.Width - Padding.Horizontal) / _zoom, 0);
 
                 using (var g = CreateGraphics())
                 {
                     _htmlContainer.PerformLayout(g);
                 }
 
-                AutoScrollMinSize = Size.Round(new SizeF(_htmlContainer.ActualSize.Width + Padding.Horizontal, _htmlContainer.ActualSize.Height));
+                AutoScrollMinSize = Size.Round(new SizeF(
+                    (_htmlContainer.ActualSize.Width + Padding.Horizontal) * _zoom,
+                    _htmlContainer.ActualSize.Height * _zoom));
             }
         }
 
@@ -491,8 +604,9 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
             {
                 e.Graphics.TextRenderingHint = _textRenderingHint;
                 e.Graphics.SetClip(ClientRectangle);
-                _htmlContainer.Location = new PointF(Padding.Left, Padding.Top);
-                _htmlContainer.ScrollOffset = AutoScrollPosition;
+                e.Graphics.ScaleTransform(_zoom, _zoom);
+                _htmlContainer.Location = new PointF(Padding.Left / _zoom, Padding.Top / _zoom);
+                SyncHtmlScrollOffset();
                 _htmlContainer.PerformPaint(e.Graphics);
 
                 if (!_lastScrollOffset.Equals(_htmlContainer.ScrollOffset))
@@ -513,13 +627,28 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         }
 
         /// <summary>
-        /// Handle mouse move to handle hover cursor and text selection. 
+        /// Handle mouse move for middle-mouse pan, hover cursor and text selection.
         /// </summary>
         protected override void OnMouseMove(MouseEventArgs e)
         {
+            if (_isPanning)
+            {
+                int dx = e.X - _panLastPoint.X;
+                int dy = e.Y - _panLastPoint.Y;
+                int scrollX = -AutoScrollPosition.X - dx;
+                int scrollY = -AutoScrollPosition.Y - dy;
+                scrollX = ClampScroll(scrollX, AutoScrollMinSize.Width, ClientSize.Width);
+                scrollY = ClampScroll(scrollY, AutoScrollMinSize.Height, ClientSize.Height);
+                AutoScrollPosition = new Point(scrollX, scrollY);
+                SyncHtmlScrollOffset();
+                _panLastPoint = e.Location;
+                Invalidate();
+                return;
+            }
+
             base.OnMouseMove(e);
             if (_htmlContainer != null)
-                _htmlContainer.HandleMouseMove(this, e);
+                _htmlContainer.HandleMouseMove(this, CreateHtmlMouseEventArgs(e));
         }
 
         /// <summary>
@@ -528,38 +657,80 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         protected override void OnMouseLeave(EventArgs e)
         {
             base.OnMouseLeave(e);
-            if (_htmlContainer != null)
+            if (!_isPanning && _htmlContainer != null)
                 _htmlContainer.HandleMouseLeave(this);
         }
 
         /// <summary>
-        /// Handle mouse down to handle selection. 
+        /// Handle mouse down for middle-mouse pan and selection.
         /// </summary>
         protected override void OnMouseDown(MouseEventArgs e)
         {
+            if (e.Button == MouseButtons.Middle)
+            {
+                StartPan(e.Location);
+                return;
+            }
+
             base.OnMouseDown(e);
             if (_htmlContainer != null)
-                _htmlContainer.HandleMouseDown(this, e);
+                _htmlContainer.HandleMouseDown(this, CreateHtmlMouseEventArgs(e));
         }
 
         /// <summary>
-        /// Handle mouse up to handle selection and link click. 
+        /// Handle mouse up for middle-mouse pan, selection and link click.
         /// </summary>
         protected override void OnMouseUp(MouseEventArgs e)
         {
-			base.OnMouseUp(e);
+            if (_isPanning && e.Button == MouseButtons.Middle)
+            {
+                EndPan();
+                return;
+            }
+
+            base.OnMouseUp(e);
             if (_htmlContainer != null)
-                _htmlContainer.HandleMouseUp(this, e);
+                _htmlContainer.HandleMouseUp(this, CreateHtmlMouseEventArgs(e));
         }
 
         /// <summary>
-        /// Handle mouse double click to select word under the mouse. 
+        /// Handle mouse double click to select word under the mouse.
         /// </summary>
         protected override void OnMouseDoubleClick(MouseEventArgs e)
         {
             base.OnMouseDoubleClick(e);
             if (_htmlContainer != null)
-                _htmlContainer.HandleMouseDoubleClick(this, e);
+                _htmlContainer.HandleMouseDoubleClick(this, CreateHtmlMouseEventArgs(e));
+        }
+
+        /// <summary>
+        /// Ctrl+MouseWheel zooms (anchor-to-cursor); otherwise normal scroll.
+        /// </summary>
+        protected override void OnMouseWheel(MouseEventArgs e)
+        {
+            if ((ModifierKeys & Keys.Control) == Keys.Control)
+            {
+                if (e.Delta > 0)
+                    ZoomIn(e.Location);
+                else if (e.Delta < 0)
+                    ZoomOut(e.Location);
+
+                if (e is HandledMouseEventArgs handled)
+                    handled.Handled = true;
+                return;
+            }
+
+            base.OnMouseWheel(e);
+        }
+
+        /// <summary>
+        /// End middle-mouse pan if mouse capture is lost.
+        /// </summary>
+        protected override void OnMouseCaptureChanged(EventArgs e)
+        {
+            base.OnMouseCaptureChanged(e);
+            if (_isPanning && !Capture)
+                EndPan();
         }
 
         /// <summary>
@@ -603,6 +774,34 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         }
 
         /// <summary>
+        /// Handle Ctrl+/-, Ctrl+=, and Ctrl+0 zoom shortcuts.
+        /// </summary>
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if ((keyData & Keys.Control) == Keys.Control)
+            {
+                Keys key = keyData & ~(Keys.Control | Keys.Shift);
+                Point anchor = GetZoomAnchorFromCursor();
+                if (key == Keys.Oemplus || key == Keys.Add)
+                {
+                    ZoomIn(anchor);
+                    return true;
+                }
+                if (key == Keys.OemMinus || key == Keys.Subtract)
+                {
+                    ZoomOut(anchor);
+                    return true;
+                }
+                if (key == Keys.D0 || key == Keys.NumPad0)
+                {
+                    SetZoom(1f, anchor);
+                    return true;
+                }
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        /// <summary>
         ///   Raises the <see cref="BorderStyleChanged" /> event.
         /// </summary>
         protected virtual void OnBorderStyleChanged(EventArgs e)
@@ -614,6 +813,16 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
             {
                 handler(this, e);
             }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="ZoomChanged"/> event.
+        /// </summary>
+        protected virtual void OnZoomChanged(EventArgs e)
+        {
+            var handler = ZoomChanged;
+            if (handler != null)
+                handler(this, e);
         }
 
         /// <summary>
@@ -685,13 +894,13 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         }
 
         /// <summary>
-        /// Adjust the scrolling of the panel to the requested location.
+        /// Adjust the scrolling of the panel to the requested location (client / zoomed space).
         /// </summary>
         /// <param name="location">the location to adjust the scroll to</param>
         protected virtual void UpdateScroll(Point location)
         {
             AutoScrollPosition = location;
-            _htmlContainer.ScrollOffset = AutoScrollPosition;
+            SyncHtmlScrollOffset();
         }
 
         /// <summary>
@@ -699,15 +908,102 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         protected virtual void InvokeMouseMove()
         {
+            if (_isPanning || _htmlContainer == null)
+                return;
+
             try
             {
-                var mp = PointToClient(MousePosition);
+                var mp = PointToHtml(PointToClient(MousePosition));
                 _htmlContainer.HandleMouseMove(this, new MouseEventArgs(MouseButtons.None, 0, mp.X, mp.Y, 0));
             }
             catch
             {
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Convert client-space point to HTML logical coordinates (accounts for zoom).
+        /// </summary>
+        private Point PointToHtml(Point clientPoint)
+        {
+            if (Math.Abs(_zoom - 1f) < 0.0001f)
+                return clientPoint;
+            return new Point(
+                (int)Math.Round(clientPoint.X / _zoom),
+                (int)Math.Round(clientPoint.Y / _zoom));
+        }
+
+        /// <summary>
+        /// Create mouse args with location converted to HTML logical coordinates.
+        /// </summary>
+        private MouseEventArgs CreateHtmlMouseEventArgs(MouseEventArgs e)
+        {
+            var p = PointToHtml(e.Location);
+            return new MouseEventArgs(e.Button, e.Clicks, p.X, p.Y, e.Delta);
+        }
+
+        /// <summary>
+        /// Sync html container scroll offset from AutoScrollPosition in logical units.
+        /// </summary>
+        private void SyncHtmlScrollOffset()
+        {
+            if (_htmlContainer == null)
+                return;
+            var sp = AutoScrollPosition;
+            _htmlContainer.ScrollOffset = new Point(
+                (int)Math.Round(sp.X / _zoom),
+                (int)Math.Round(sp.Y / _zoom));
+        }
+
+        /// <summary>
+        /// Clamp a positive scroll offset to the valid range for the current content size.
+        /// </summary>
+        private static int ClampScroll(int offset, int contentSize, int viewportSize)
+        {
+            int max = Math.Max(0, contentSize - viewportSize);
+            if (offset < 0)
+                return 0;
+            if (offset > max)
+                return max;
+            return offset;
+        }
+
+        /// <summary>
+        /// Start middle-mouse pan at the given client point.
+        /// </summary>
+        private void StartPan(Point clientPoint)
+        {
+            _isPanning = true;
+            _panLastPoint = clientPoint;
+            _cursorBeforePan = Cursor;
+            Cursor = Cursors.SizeAll;
+            Capture = true;
+            Focus();
+        }
+
+        /// <summary>
+        /// End middle-mouse pan and restore cursor/capture.
+        /// </summary>
+        private void EndPan()
+        {
+            if (!_isPanning)
+                return;
+            _isPanning = false;
+            Capture = false;
+            Cursor = _cursorBeforePan ?? Cursors.Default;
+            InvokeMouseMove();
+        }
+
+        /// <summary>
+        /// Client point under the cursor if it is over this control; otherwise viewport center.
+        /// </summary>
+        private Point GetZoomAnchorFromCursor()
+        {
+            var client = PointToClient(MousePosition);
+            if (ClientRectangle.Contains(client))
+                return client;
+            return new Point(ClientSize.Width / 2, ClientSize.Height / 2);
         }
 
         /// <summary>

--- a/Source/HtmlRenderer.WinForms/HtmlRenderer.WinForms.csproj
+++ b/Source/HtmlRenderer.WinForms/HtmlRenderer.WinForms.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>TheArtOfDev.HtmlRenderer.WinForms</RootNamespace>
     <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
 	<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-	<EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <!-- NuGet Package Properties -->
   <PropertyGroup>

--- a/Source/HtmlRenderer.WinForms/HtmlToolTip.cs
+++ b/Source/HtmlRenderer.WinForms/HtmlToolTip.cs
@@ -31,17 +31,17 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// <summary>
         /// the container to render and handle the html shown in the tooltip
         /// </summary>
-        protected HtmlContainer _htmlContainer;
+        protected HtmlContainer? _htmlContainer;
 
         /// <summary>
         /// the raw base stylesheet data used in the control
         /// </summary>
-        protected string _baseRawCssData;
+        protected string? _baseRawCssData;
 
         /// <summary>
         /// the base stylesheet data used in the panel
         /// </summary>
-        protected CssData _baseCssData;
+        protected CssData? _baseCssData;
 
         /// <summary>
         /// The text rendering hint to be used for text rendering.
@@ -57,13 +57,13 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// the control that the tooltip is currently showing on.<br/>
         /// Used for link handling.
         /// </summary>
-        private Control _associatedControl;
+        private Control? _associatedControl;
 
         /// <summary>
         /// timer used to handle mouse move events when mouse is over the tooltip.<br/>
         /// Used for link handling.
         /// </summary>
-        private Timer _linkHandlingTimer;
+        private Timer? _linkHandlingTimer;
 
         /// <summary>
         /// the handle of the actual tooltip window used to know when the tooltip is hidden<br/>
@@ -175,7 +175,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         [Description("Set base stylesheet to be used by html rendered in the tooltip.")]
         [Category("Appearance")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Design, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        [Editor("System.ComponentModel.Design.MultilineStringEditor, System.Windows.Forms.Design, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Drawing.Design.UITypeEditor, System.Windows.Forms, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
         public virtual string BaseStylesheet
         {
             get { return _baseRawCssData; }
@@ -238,6 +238,9 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
         /// </summary>
         protected virtual void OnToolTipPopup(PopupEventArgs e)
         {
+            if (e.AssociatedControl == null)
+                return;
+
             //Create fragment container
             var cssClass = string.IsNullOrEmpty(_tooltipCssClass) ? null : string.Format(" class=\"{0}\"", _tooltipCssClass);
             var toolipHtml = string.Format("<div{0}>{1}</div>", cssClass, GetToolTip(e.AssociatedControl));
@@ -276,7 +279,8 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                 _tooltipHandle = Win32Utils.WindowFromDC(hdc);
                 e.Graphics.ReleaseHdc(hdc);
 
-                AdjustTooltipPosition(e.AssociatedControl, e.Bounds.Size);
+                if (e.AssociatedControl != null)
+                    AdjustTooltipPosition(e.AssociatedControl, e.Bounds.Size);
             }
 
             e.Graphics.Clear(Color.White);
@@ -373,16 +377,19 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                     _linkHandlingTimer.Stop();
                     _tooltipHandle = IntPtr.Zero;
 
-                    var mPos = Control.MousePosition;
-                    var mButtons = Control.MouseButtons;
-                    var rect = Win32Utils.GetWindowRectangle(handle);
-                    if (rect.Contains(mPos))
+                    if (handle != IntPtr.Zero && _associatedControl != null)
                     {
-                        if (mButtons == MouseButtons.Left)
+                        var mPos = Control.MousePosition;
+                        var mButtons = Control.MouseButtons;
+                        var rect = Win32Utils.GetWindowRectangle(handle);
+                        if (rect.Contains(mPos))
                         {
-                            var args = new MouseEventArgs(mButtons, 1, mPos.X - rect.X, mPos.Y - rect.Y, 0);
-                            _htmlContainer.HandleMouseDown(_associatedControl, args);
-                            _htmlContainer.HandleMouseUp(_associatedControl, args);
+                            if (mButtons == MouseButtons.Left)
+                            {
+                                var args = new MouseEventArgs(mButtons, 1, mPos.X - rect.X, mPos.Y - rect.Y, 0);
+                                _htmlContainer.HandleMouseDown(_associatedControl, args);
+                                _htmlContainer.HandleMouseUp(_associatedControl, args);
+                            }
                         }
                     }
                 }
@@ -402,22 +409,21 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
             Draw -= OnToolTipDraw;
             Disposed -= OnToolTipDisposed;
 
+            if (_linkHandlingTimer != null)
+            {
+                _linkHandlingTimer.Tick -= OnLinkHandlingTimerTick;
+                _linkHandlingTimer.Dispose();
+                _linkHandlingTimer = null;
+            }
+
             if (_htmlContainer != null)
             {
+                _htmlContainer.LinkClicked -= OnLinkClicked;
                 _htmlContainer.RenderError -= OnRenderError;
                 _htmlContainer.StylesheetLoad -= OnStylesheetLoad;
                 _htmlContainer.ImageLoad -= OnImageLoad;
                 _htmlContainer.Dispose();
                 _htmlContainer = null;
-            }
-
-            if (_linkHandlingTimer != null)
-            {
-                _linkHandlingTimer.Dispose();
-                _linkHandlingTimer = null;
-
-                if (_htmlContainer != null)
-                    _htmlContainer.LinkClicked -= OnLinkClicked;
             }
         }
 

--- a/Source/HtmlRenderer.WinForms/MetafileExtensions.cs
+++ b/Source/HtmlRenderer.WinForms/MetafileExtensions.cs
@@ -14,24 +14,25 @@ namespace TheArtOfDev.HtmlRenderer.WinForms
                 by : SWAT Team member _1 
                 Date : Friday, February 01, 2008 1:38 PM 
                 */
-            int enfMetafileHandle = me.GetHenhmetafile().ToInt32();
+            IntPtr enfMetafileHandle = me.GetHenhmetafile();
             int bufferSize = GetEnhMetaFileBits(enfMetafileHandle, 0, null); // Get required buffer size.  
             byte[] buffer = new byte[bufferSize]; // Allocate sufficient buffer  
             if (GetEnhMetaFileBits(enfMetafileHandle, bufferSize, buffer) <= 0) // Get raw metafile data.  
                 throw new SystemException("Fail");
 
-            FileStream ms = File.Open(fileName, FileMode.Create);
-            ms.Write(buffer, 0, bufferSize);
-            ms.Close();
-            ms.Dispose();
+            using (var ms = File.Open(fileName, FileMode.Create))
+            {
+                ms.Write(buffer, 0, bufferSize);
+            }
+
             if (!DeleteEnhMetaFile(enfMetafileHandle)) //free handle  
                 throw new SystemException("Fail Free");
         }
 
-        [DllImport("gdi32")]
-        public static extern int GetEnhMetaFileBits(int hemf, int cbBuffer, byte[] lpbBuffer);
+        [DllImport("gdi32.dll")]
+        public static extern int GetEnhMetaFileBits(IntPtr hemf, int cbBuffer, byte[] lpbBuffer);
 
-        [DllImport("gdi32")]
-        public static extern bool DeleteEnhMetaFile(int hemfbitHandle);
+        [DllImport("gdi32.dll")]
+        public static extern bool DeleteEnhMetaFile(IntPtr hemfbitHandle);
     }  
 }

--- a/Source/HtmlRenderer.WinForms/Utilities/Utils.cs
+++ b/Source/HtmlRenderer.WinForms/Utilities/Utils.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Drawing;
 using TheArtOfDev.HtmlRenderer.Adapters.Entities;
+using TheArtOfDev.HtmlRenderer.Core.Utils;
 
 namespace TheArtOfDev.HtmlRenderer.WinForms.Utilities
 {
@@ -34,6 +35,7 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Utilities
         /// </summary>
         public static PointF[] Convert(RPoint[] points)
         {
+            ArgChecker.AssertArgNotNull(points, nameof(points));
             PointF[] myPoints = new PointF[points.Length];
             for (int i = 0; i < points.Length; i++)
                 myPoints[i] = Convert(points[i]);

--- a/Source/HtmlRenderer.WinForms/Utilities/Win32Utils.cs
+++ b/Source/HtmlRenderer.WinForms/Utilities/Win32Utils.cs
@@ -47,11 +47,11 @@ namespace TheArtOfDev.HtmlRenderer.WinForms.Utilities
 
         public const int TextAlignBaselineRtl = 256 + 24;
 
-        [DllImport("user32.dll")]
-        public static extern int SetCursor(int hCursor);
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr SetCursor(IntPtr hCursor);
 
-        [DllImport("user32.dll")]
-        public static extern int LoadCursor(int hInstance, int lpCursorName);
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr LoadCursor(IntPtr hInstance, int lpCursorName);
 
         /// <summary>
         /// Create a compatible memory HDC from the given HDC.<br/>

--- a/Source/HtmlRenderer/Adapters/Entities/RColor.cs
+++ b/Source/HtmlRenderer/Adapters/Entities/RColor.cs
@@ -211,7 +211,7 @@ namespace TheArtOfDev.HtmlRenderer.Adapters.Entities
         /// </returns>
         /// <param name="obj">The object to test. </param>
         /// <filterpriority>1</filterpriority>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is RColor)
             {

--- a/Source/HtmlRenderer/Adapters/Entities/RPoint.cs
+++ b/Source/HtmlRenderer/Adapters/Entities/RPoint.cs
@@ -251,7 +251,7 @@ namespace TheArtOfDev.HtmlRenderer.Adapters.Entities
         ///     The <see cref="T:System.Object" /> to test.
         /// </param>
         /// <filterpriority>1</filterpriority>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is RPoint))
                 return false;

--- a/Source/HtmlRenderer/Adapters/Entities/RRect.cs
+++ b/Source/HtmlRenderer/Adapters/Entities/RRect.cs
@@ -284,7 +284,7 @@ namespace TheArtOfDev.HtmlRenderer.Adapters.Entities
         /// <param name="obj">
         ///     The <see cref="T:System.Object" /> to test.
         /// </param>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is RRect))
                 return false;

--- a/Source/HtmlRenderer/Adapters/Entities/RSize.cs
+++ b/Source/HtmlRenderer/Adapters/Entities/RSize.cs
@@ -287,7 +287,7 @@ namespace TheArtOfDev.HtmlRenderer.Adapters.Entities
         ///     The <see cref="T:System.Object" /> to test.
         /// </param>
         /// <filterpriority>1</filterpriority>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is RSize))
                 return false;

--- a/Source/HtmlRenderer/Adapters/RAdapter.cs
+++ b/Source/HtmlRenderer/Adapters/RAdapter.cs
@@ -365,7 +365,7 @@ namespace TheArtOfDev.HtmlRenderer.Adapters
         /// </summary>
         /// <param name="image">the image returned from load event</param>
         /// <returns>converted image or null</returns>
-        protected abstract RImage ConvertImageInt(object image);
+        protected abstract RImage? ConvertImageInt(object? image);
 
         /// <summary>
         /// Create an <see cref="RImage"/> object from the given stream.

--- a/Source/HtmlRenderer/Core/Entities/CssBlock.cs
+++ b/Source/HtmlRenderer/Core/Entities/CssBlock.cs
@@ -196,7 +196,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Entities
         /// </summary>
         /// <param name="obj">the other block to compare to</param>
         /// <returns>true - the two blocks are the same, false - otherwise</returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
                 return false;

--- a/Source/HtmlRenderer/Core/Handlers/ImageDownloader.cs
+++ b/Source/HtmlRenderer/Core/Handlers/ImageDownloader.cs
@@ -39,9 +39,14 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
     internal sealed class ImageDownloader : IDisposable
     {
         /// <summary>
-        /// the web client used to download image from URL (to cancel on dispose)
+        /// List of web clients used to download images (to allow cancel on dispose).
         /// </summary>
         private readonly List<WebClient> _clients = new List<WebClient>();
+
+        /// <summary>
+        /// Lock object for thread-safe _clients access.
+        /// </summary>
+        private readonly object _clientsLock = new object();
 
         /// <summary>
         /// dictionary of image cache path to callbacks of download to handle multiple requests to download the same image 
@@ -111,7 +116,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
             {
                 using (var client = new WebClient())
                 {
-                    _clients.Add(client);
+                    lock (_clientsLock) { _clients.Add(client); }
                     client.DownloadFile(source, tempPath);
                     OnDownloadImageCompleted(client, source, tempPath, filePath, null, false);
                 }
@@ -133,7 +138,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
             try
             {
                 var client = new WebClient();
-                _clients.Add(client);
+                lock (_clientsLock) { _clients.Add(client); }
                 client.DownloadFileCompleted += OnDownloadImageAsyncCompleted;
                 client.DownloadFileAsync(downloadData._uri, downloadData._tempPath, downloadData);
             }
@@ -226,17 +231,20 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
         private void ReleaseObjects()
         {
             _imageDownloadCallbacks.Clear();
-            while (_clients.Count > 0)
+            lock (_clientsLock)
             {
-                try
+                while (_clients.Count > 0)
                 {
-                    var client = _clients[0];
-                    client.CancelAsync();
-                    client.Dispose();
-                    _clients.RemoveAt(0);
+                    try
+                    {
+                        var client = _clients[0];
+                        client.CancelAsync();
+                        client.Dispose();
+                        _clients.RemoveAt(0);
+                    }
+                    catch
+                    { }
                 }
-                catch
-                { }
             }
         }
 

--- a/Source/HtmlRenderer/Core/Handlers/ImageLoadHandler.cs
+++ b/Source/HtmlRenderer/Core/Handlers/ImageLoadHandler.cs
@@ -55,6 +55,11 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
         private readonly ActionInt<RImage, RRect, bool> _loadCompleteCallback;
 
         /// <summary>
+        /// Dedicated lock object (instead of locking on the callback delegate).
+        /// </summary>
+        private readonly object _syncLock = new object();
+
+        /// <summary>
         /// Must be open as long as the image is in use
         /// </summary>
         private FileStream _imageFileStream;
@@ -302,7 +307,7 @@ namespace TheArtOfDev.HtmlRenderer.Core.Handlers
             try
             {
                 var imageFileStream = File.Open(source, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                lock (_loadCompleteCallback)
+                lock (_syncLock)
                 {
                     _imageFileStream = imageFileStream;
                     if (!_disposed)

--- a/Source/HtmlRenderer/Core/HtmlContainerInt.cs
+++ b/Source/HtmlRenderer/Core/HtmlContainerInt.cs
@@ -460,7 +460,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// <summary>
         /// Get the currently selected text segment in the html.
         /// </summary>
-        public string SelectedText
+        public string? SelectedText
         {
             get { return _selectionHandler.GetSelectedText(); }
         }
@@ -468,7 +468,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// <summary>
         /// Copy the currently selected html segment with style.
         /// </summary>
-        public string SelectedHtml
+        public string? SelectedHtml
         {
             get { return _selectionHandler.GetSelectedHtml(); }
         }
@@ -504,7 +504,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// </summary>
         /// <param name="htmlSource">the html to init with, init empty if not given</param>
         /// <param name="baseCssData">optional: the stylesheet to init with, init default if not given</param>
-        public void SetHtml(string htmlSource, CssData baseCssData = null)
+        public void SetHtml(string? htmlSource, CssData? baseCssData = null)
         {
             Clear();
             if (!string.IsNullOrEmpty(htmlSource))
@@ -561,7 +561,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// </summary>
         /// <param name="styleGen">Optional: controls the way styles are generated when html is generated (default: <see cref="HtmlGenerationStyle.Inline"/>)</param>
         /// <returns>generated html</returns>
-        public string GetHtml(HtmlGenerationStyle styleGen = HtmlGenerationStyle.Inline)
+        public string? GetHtml(HtmlGenerationStyle styleGen = HtmlGenerationStyle.Inline)
         {
             return DomUtils.GenerateHtml(_root, styleGen);
         }
@@ -573,7 +573,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// <param name="location">the location to find the attribute at</param>
         /// <param name="attribute">the attribute key to get value by</param>
         /// <returns>found attribute value or null if not found</returns>
-        public string GetAttributeAt(RPoint location, string attribute)
+        public string? GetAttributeAt(RPoint location, string attribute)
         {
             ArgChecker.AssertArgNotNullOrEmpty(attribute, "attribute");
 
@@ -603,7 +603,7 @@ namespace TheArtOfDev.HtmlRenderer.Core
         /// </summary>
         /// <param name="location">the location to find the link at</param>
         /// <returns>css link href if exists or null</returns>
-        public string GetLinkAt(RPoint location)
+        public string? GetLinkAt(RPoint location)
         {
             var link = DomUtils.GetLinkBox(_root, OffsetByScroll(location));
             return link != null ? link.HrefLink : null;

--- a/Source/HtmlRenderer/HtmlRenderer.csproj
+++ b/Source/HtmlRenderer/HtmlRenderer.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>TheArtOfDev.HtmlRenderer</RootNamespace>
+    <Nullable>enable</Nullable>
 	<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-	<EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <!-- NuGet Package Properties -->
   <PropertyGroup>

--- a/Source/HtmlRenderer/HtmlRenderer.csproj
+++ b/Source/HtmlRenderer/HtmlRenderer.csproj
@@ -26,6 +26,6 @@ For existing implementations see: HtmlRenderer.WinForms, HtmlRenderer.WPF and Ht
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-	<PackageReference Include="System.Resources.Extensions" Version="10.0.1" />
+	<PackageReference Include="System.Resources.Extensions" Version="10.0.10" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Adds browser-style **zoom** and **middle-button pan** to `HtmlPanel`.

### Features
- **Ctrl + mouse wheel**: zoom in/out, anchor-to-cursor
- **Ctrl + / − / 0**: zoom in, zoom out, reset (optional keyboard path)
- **Middle mouse button drag**: pan when content is zoomed/scrollable
- When zoomed, paint uses `Graphics` scale transform and forces **GDI+** text so glyphs scale (GDI `TextOut` ignores `ScaleTransform`)

### Depends on
This branch is **stacked on** #246 (`.NET 10` modernization).  
Please review/merge **#246 first**. After that, this PR can be rebased onto `master` if needed.

### Test plan
- [x] `dotnet build -c Release` HtmlRenderer.WinForms on this branch
- [ ] Manual: Ctrl+wheel zoom over content anchors to cursor
- [ ] Manual: middle-drag pans
- [ ] Manual: Ctrl+0 resets zoom

### Scope
WinForms `HtmlPanel` (+ small `GraphicsAdapter` support). No Core TFM changes beyond #246.