### PR TITLE
Fix PDF page orientation

### DIFF
--- a/Source/HtmlRenderer.PdfSharp/PdfGenerator.cs
+++ b/Source/HtmlRenderer.PdfSharp/PdfGenerator.cs
@@ -173,6 +173,7 @@ namespace TheArtOfDev.HtmlRenderer.PdfSharp
                         var page = document.AddPage();
                         page.Height = XUnit.FromPoint(orgPageSize.Height);
                         page.Width = XUnit.FromPoint(orgPageSize.Width);
+                        page.Orientation = config.PageOrientation;
 
                         using (var g = XGraphics.FromPdfPage(page))
                         {


### PR DESCRIPTION
Inspired by https://github.com/george-pov/HTML-Renderer-Core/commit/743821f61371c058196e3ed082ed2e66669e5a3a

The current code is missing the adjustment of the page configuration for a given page.