### PR TITLE
Enable PDF rendering in the WPF demo

### DIFF
--- a/Source/Demo/WPF/DemoWindow.xaml
+++ b/Source/Demo/WPF/DemoWindow.xaml
@@ -43,7 +43,7 @@
                         <TextBlock Text="Generate Image" VerticalAlignment="Center"/>
                     </StackPanel>
                 </Button>
-                <Button IsEnabled="False">
+                <Button Click="OnGeneratePdf_Click">
                     <StackPanel Orientation="Horizontal">
                         <Image Source="{Binding ConverterParameter=pdf, Converter={StaticResource Converter}}" MaxHeight="18" Margin="0 0 5 0"/>
                         <TextBlock Text="Generate PDF" VerticalAlignment="Center"/>

--- a/Source/Demo/WPF/DemoWindow.xaml.cs
+++ b/Source/Demo/WPF/DemoWindow.xaml.cs
@@ -17,7 +17,9 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Threading;
 using TheArtOfDev.HtmlRenderer.Demo.Common;
+using TheArtOfDev.HtmlRenderer.PdfSharp;
 using TheArtOfDev.HtmlRenderer.WPF;
+using PdfSharp;
 
 namespace TheArtOfDev.HtmlRenderer.Demo.WPF
 {
@@ -109,6 +111,24 @@ namespace TheArtOfDev.HtmlRenderer.Demo.WPF
             w.Width = Width * 0.8;
             w.Height = Height * 0.8;
             w.ShowDialog();
+        }
+
+        /// <summary>
+        /// Create PDF using PdfSharp project, save to file and open that file.
+        /// </summary>
+        private void OnGeneratePdf_Click(object sender, RoutedEventArgs e)
+        {
+            var config = new PdfGenerateConfig();
+            config.PageSize = PageSize.A4;
+            config.SetMargins(20);
+
+            var doc = PdfGenerator.GeneratePdf(_mainControl.GetHtml(), config, null, DemoUtils.OnStylesheetLoad, HtmlRenderingHelper.OnImageLoadPdfSharp);
+
+            var tmpFile = Path.GetTempFileName();
+            var pdfFile = Path.ChangeExtension(tmpFile, ".pdf");
+            doc.Save(pdfFile);
+
+            Process.Start(new ProcessStartInfo(pdfFile) { UseShellExecute = true });
         }
 
         /// <summary>

--- a/Source/Demo/WPF/HtmlRenderer.Demo.WPF.csproj
+++ b/Source/Demo/WPF/HtmlRenderer.Demo.WPF.csproj
@@ -15,6 +15,7 @@
     <AppDesigner Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\HtmlRenderer.PdfSharp\HtmlRenderer.PdfSharp.csproj" />
     <ProjectReference Include="..\..\HtmlRenderer.WPF\HtmlRenderer.WPF.csproj" />
     <ProjectReference Include="..\..\HtmlRenderer\HtmlRenderer.csproj" />
     <ProjectReference Include="..\Common\HtmlRenderer.Demo.Common.csproj" />

--- a/Source/Demo/WPF/HtmlRenderingHelper.cs
+++ b/Source/Demo/WPF/HtmlRenderingHelper.cs
@@ -16,6 +16,7 @@ using System.IO;
 using System.Threading;
 using System.Windows;
 using System.Windows.Media.Imaging;
+using PdfSharp.Drawing;
 using TheArtOfDev.HtmlRenderer.Core.Entities;
 using TheArtOfDev.HtmlRenderer.Demo.Common;
 using TheArtOfDev.HtmlRenderer.WPF;
@@ -60,6 +61,7 @@ namespace TheArtOfDev.HtmlRenderer.Demo.WPF
                     return new PngBitmapEncoder();
 
             }
+
         }
 
         /// <summary>
@@ -121,9 +123,26 @@ namespace TheArtOfDev.HtmlRenderer.Demo.WPF
         /// <summary>
         /// On image load in renderer set the image by event async.
         /// </summary>
+        public static void OnImageLoadPdfSharp(object sender, HtmlImageLoadEventArgs args)
+        {
+            ImageLoad(args, true);
+        }
+
+        /// <summary>
+        /// On image load in renderer set the image by event async.
+        /// </summary>
         public static void ImageLoad(HtmlImageLoadEventArgs e)
         {
+            ImageLoad(e, false);
+        }
+
+        /// <summary>
+        /// On image load in renderer set the image by event async.
+        /// </summary>
+        public static void ImageLoad(HtmlImageLoadEventArgs e, bool pdfSharp)
+        {
             var img = TryLoadResourceImage(e.Src);
+            var imgObj = pdfSharp ? (object)(img != null ? CreatePdfSharpImage(img) : null) : img;
 
             if (!e.Handled && e.Attributes != null)
             {
@@ -150,13 +169,31 @@ namespace TheArtOfDev.HtmlRenderer.Demo.WPF
                 {
                     var split = e.Attributes["byrect"].Split(',');
                     var rect = new Rect(Int32.Parse(split[0]), Int32.Parse(split[1]), Int32.Parse(split[2]), Int32.Parse(split[3]));
-                    e.Callback(img ?? TryLoadResourceImage("htmlicon"), rect.X, rect.Y, rect.Width, rect.Height);
+                    var defaultResourceImage = TryLoadResourceImage("htmlicon");
+                    var defaultImg = pdfSharp && defaultResourceImage != null ? (object)CreatePdfSharpImage(defaultResourceImage) : defaultResourceImage;
+                    e.Callback(imgObj ?? defaultImg, rect.X, rect.Y, rect.Width, rect.Height);
                     return;
                 }
             }
 
             if (img != null)
-                e.Callback(img);
+                e.Callback(imgObj);
+        }
+
+        /// <summary>
+        /// Convert image to PNG before creating <see cref="XImage"/> because PdfSharp does not support GIF streams.
+        /// </summary>
+        private static XImage CreatePdfSharpImage(BitmapSource image)
+        {
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(image));
+
+            using (var ms = new MemoryStream())
+            {
+                encoder.Save(ms);
+                ms.Position = 0;
+                return XImage.FromStream(ms);
+            }
         }
     }
 }


### PR DESCRIPTION
The WPF Demo had the Generate PDF button disabled, because it was missing an image handling option.

Now the WPF Demo can also generate PDFs.